### PR TITLE
ReSnap ports after changing of a node

### DIFF
--- a/src/features/dfdElements/di.config.ts
+++ b/src/features/dfdElements/di.config.ts
@@ -15,7 +15,7 @@ import { FunctionNodeImpl, FunctionNodeView, IONodeImpl, IONodeView, StorageNode
 import { ArrowEdgeImpl, ArrowEdgeView, CustomRoutingHandleView } from "./edges";
 import { DfdInputPortImpl, DfdInputPortView, DfdOutputPortImpl, DfdOutputPortView } from "./ports";
 import { FilledBackgroundLabelView, DfdPositionalLabelView } from "./labels";
-import { AlwaysSnapPortsMoveMouseListener, PortAwareSnapper } from "./portSnapper";
+import { AlwaysSnapPortsMoveMouseListener, ReSnapPortsAfterLabelChangeCommand, PortAwareSnapper } from "./portSnapper";
 import {
     OutputPortEditUIMouseListener,
     OutputPortEditUI,
@@ -31,6 +31,7 @@ export const dfdElementsModule = new ContainerModule((bind, unbind, isBound, reb
 
     rebind(TYPES.ISnapper).to(PortAwareSnapper).inSingletonScope();
     bind(TYPES.MouseListener).to(AlwaysSnapPortsMoveMouseListener).inSingletonScope();
+    configureCommand(context, ReSnapPortsAfterLabelChangeCommand);
 
     bind(PortBehaviorValidator).toSelf().inSingletonScope();
     bind(TYPES.IUIExtension).to(OutputPortEditUI).inSingletonScope();

--- a/src/features/dfdElements/nodes.tsx
+++ b/src/features/dfdElements/nodes.tsx
@@ -219,11 +219,11 @@ export class FunctionNodeView extends ShapeView {
         return (
             <g class-sprotty-node={true} class-function={true}>
                 <rect x="0" y="0" width={width} height={height} rx={r} ry={r} />
+                <line x1="0" y1={FunctionNodeImpl.TEXT_HEIGHT} x2={width} y2={FunctionNodeImpl.TEXT_HEIGHT} />
                 {context.renderChildren(node, {
                     xPosition: width / 2,
                     yPosition: FunctionNodeImpl.TEXT_HEIGHT / 2,
                 } as DfdPositionalLabelArgs)}
-                <line x1="0" y1={FunctionNodeImpl.TEXT_HEIGHT} x2={width} y2={FunctionNodeImpl.TEXT_HEIGHT} />
                 {this.labelRenderer.renderNodeLabels(node, FunctionNodeImpl.LABEL_START_HEIGHT)}
             </g>
         );

--- a/src/features/dfdElements/portSnapper.ts
+++ b/src/features/dfdElements/portSnapper.ts
@@ -1,6 +1,20 @@
-import { injectable } from "inversify";
-import { CenterGridSnapper, ISnapper, MoveMouseListener, SModelElementImpl, SPortImpl, isBoundsAware } from "sprotty";
-import { Point } from "sprotty-protocol";
+import { inject, injectable } from "inversify";
+import {
+    CenterGridSnapper,
+    Command,
+    CommandExecutionContext,
+    ApplyLabelEditCommand,
+    CommandReturn,
+    ISnapper,
+    MoveMouseListener,
+    SChildElementImpl,
+    SModelElementImpl,
+    SNodeImpl,
+    SPortImpl,
+    TYPES,
+    isBoundsAware,
+} from "sprotty";
+import { ApplyLabelEditAction, Point } from "sprotty-protocol";
 
 /**
  * A grid snapper that snaps to the nearest grid point.
@@ -96,4 +110,74 @@ export class AlwaysSnapPortsMoveMouseListener extends MoveMouseListener {
             return position;
         }
     }
+}
+
+/**
+ * Command that snaps all ports of the node to the grid after a label was added/removed.
+ * Runs after {@link ApplyLabelEditAction} to ensure the ports are snapped to the grid after the label was moved.
+ *
+ * This is done by implementing another command for {@link ApplyLabelEditAction}
+ * and registering it as well. That way this command will be executed after the {@link ApplyLabelEditCommand}
+ */
+@injectable()
+export class ReSnapPortsAfterLabelChangeCommand extends Command {
+    static readonly KIND = ApplyLabelEditAction.KIND;
+
+    @inject(TYPES.ISnapper)
+    private snapper?: ISnapper;
+
+    constructor(@inject(TYPES.Action) private readonly action: ApplyLabelEditAction) {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): CommandReturn {
+        const label = context.root.index.getById(this.action.labelId);
+        if (!(label instanceof SChildElementImpl) || !this.snapper) {
+            return context.root;
+        }
+
+        const node = label.parent;
+        if (!(node instanceof SNodeImpl)) {
+            return context.root;
+        }
+
+        snapPortsOfNode(node, this.snapper);
+        return context.root;
+    }
+
+    // undo/redo: resnap aswell. Same as execute
+
+    undo(context: CommandExecutionContext): CommandReturn {
+        return this.execute(context);
+    }
+
+    redo(context: CommandExecutionContext): CommandReturn {
+        return this.execute(context);
+    }
+}
+
+/**
+ * Snaps all ports of the given node to the grid using the given snapper.
+ * Useful to ensure all ports are on are snapped onto an node edge using
+ * {@link PortAwareSnapper} after resizing the node.
+ */
+export function snapPortsOfNode(node: SNodeImpl, snapper: ISnapper): void {
+    if (!(node instanceof SChildElementImpl)) {
+        // Element has no children which could be ports
+        return;
+    }
+
+    node.children.forEach((child) => {
+        if (child instanceof SPortImpl) {
+            // PortAwareSnapper expects the center of the port as input.
+            // However the stored position points to the top left of the port,
+            // so we need to adjust the position by half of the width/height.
+            const pos = { ...child.position };
+            const { width, height } = child.bounds;
+            pos.x += width / 2;
+            pos.y += height / 2;
+
+            child.position = snapper.snap(pos, child);
+        }
+    });
 }

--- a/src/features/labels/dropListener.ts
+++ b/src/features/labels/dropListener.ts
@@ -1,7 +1,15 @@
 import { injectable, inject } from "inversify";
 import { LabelAssignment } from "./labelTypeRegistry";
 import { Action } from "sprotty-protocol";
-import { SModelElementImpl, SChildElementImpl, MouseListener, CommitModelAction, ILogger, TYPES } from "sprotty";
+import {
+    SModelElementImpl,
+    SChildElementImpl,
+    MouseListener,
+    CommitModelAction,
+    ILogger,
+    TYPES,
+    SNodeImpl,
+} from "sprotty";
 import { AddLabelAssignmentAction } from "./commands";
 import { getParentWithDfdLabels } from "./elementFeature";
 
@@ -37,6 +45,11 @@ export class DfdLabelMouseDropListener extends MouseListener {
                 this,
                 "Aborted drop of label assignment because the target element nor the parent elements have the dfd label feature",
             );
+            return [];
+        }
+
+        if (!(dfdLabelElement instanceof SNodeImpl)) {
+            this.logger.info(this, "Aborted drop of label assignment because the target element is not a node");
             return [];
         }
 

--- a/src/features/labels/elementFeature.ts
+++ b/src/features/labels/elementFeature.ts
@@ -1,4 +1,4 @@
-import { SChildElementImpl, SModelElementImpl, SModelExtension, SParentElementImpl } from "sprotty";
+import { SChildElementImpl, SModelElementImpl, SModelExtension, SParentElementImpl, SShapeElementImpl } from "sprotty";
 import { LabelAssignment } from "./labelTypeRegistry";
 
 export const containsDfdLabelFeature = Symbol("dfd-label-feature");
@@ -14,7 +14,9 @@ export function containsDfdLabels<T extends SModelElementImpl>(element: T): elem
 // Traverses the graph upwards to find any element having the dfd label feature.
 // This is needed because you may select/drop onto a child element of the node implementing and displaying dfd labels.
 // If the element itself and no parent has the feature undefined is returned.
-export function getParentWithDfdLabels(element: SChildElementImpl | SParentElementImpl): ContainsDfdLabels | undefined {
+export function getParentWithDfdLabels(
+    element: SChildElementImpl | SParentElementImpl | SShapeElementImpl,
+): (SModelElementImpl & ContainsDfdLabels) | undefined {
     if (containsDfdLabels(element)) {
         return element;
     }

--- a/src/features/labels/labelRenderer.tsx
+++ b/src/features/labels/labelRenderer.tsx
@@ -1,7 +1,7 @@
 /** @jsx svg */
 import { injectable, inject } from "inversify";
 import { VNode } from "snabbdom";
-import { Hoverable, IActionDispatcher, SShapeElementImpl, TYPES, svg } from "sprotty";
+import { IActionDispatcher, SNodeImpl, TYPES, svg } from "sprotty";
 import { calculateTextSize } from "../../utils";
 import { LabelAssignment, LabelTypeRegistry, globalLabelTypeRegistry } from "./labelTypeRegistry";
 import { DeleteLabelAssignmentAction } from "./commands";
@@ -37,12 +37,7 @@ export class DfdNodeLabelRenderer {
         return [text, width];
     }
 
-    renderSingleNodeLabel(
-        node: ContainsDfdLabels & SShapeElementImpl & Hoverable,
-        label: LabelAssignment,
-        x: number,
-        y: number,
-    ): VNode {
+    renderSingleNodeLabel(node: ContainsDfdLabels & SNodeImpl, label: LabelAssignment, x: number, y: number): VNode {
         const [text, width] = DfdNodeLabelRenderer.computeLabelContent(label);
         const xLeft = x - width / 2;
         const xRight = x + width / 2;
@@ -105,7 +100,7 @@ export class DfdNodeLabelRenderer {
     }
 
     renderNodeLabels(
-        node: ContainsDfdLabels & SShapeElementImpl & Hoverable,
+        node: ContainsDfdLabels & SNodeImpl,
         baseY: number,
         xOffset = 0,
         labelSpacing = DfdNodeLabelRenderer.LABEL_SPACING_HEIGHT,

--- a/src/features/serialize/loadDefaultDiagram.ts
+++ b/src/features/serialize/loadDefaultDiagram.ts
@@ -71,7 +71,7 @@ const defaultDiagramSchema: SGraph = {
                 {
                     type: "port:dfd-input",
                     id: functionPort1Id,
-                    position: { x: 10, y: -3.5 },
+                    position: { x: 11, y: -3.5 },
                 },
                 {
                     type: "port:dfd-output",


### PR DESCRIPTION
Reruns snap algorithm after a node has either changed dfd labels or label change. This causes a node size change which would leave the port stranding somewhere on not the node edge. To fix this, this PR re-runs snapping after a those two actions.