### PR TITLE
Add copy and paste feature

### DIFF
--- a/src/common/copyPaste.ts
+++ b/src/common/copyPaste.ts
@@ -1,24 +1,36 @@
 import {
     CommitModelAction,
+    IModelFactory,
     KeyListener,
     SChildElementImpl,
+    SEdgeImpl,
     SModelElementImpl,
     SModelRootImpl,
     SNodeImpl,
+    TYPES,
     isSelected,
 } from "sprotty";
-import { Action, CreateElementAction } from "sprotty-protocol";
+import { Action, SPort, SelectAction } from "sprotty-protocol";
 import { matchesKeystroke } from "sprotty/lib/utils/keyboard";
 import { generateRandomSprottyId } from "../utils";
 import { DynamicChildrenProcessor } from "../features/dfdElements/dynamicChildren";
 import { injectable, inject } from "inversify";
+import { DfdNode, DfdNodeImpl } from "../features/dfdElements/nodes";
+import { ArrowEdge, ArrowEdgeImpl } from "../features/dfdElements/edges";
 
+/**
+ * This feature allows the user to copy and paste elements.
+ * When ctrl+c is pressed, all selected elements are copied into an internal array.
+ * When ctrl+v is pressed, all elements in the internal array are pasted with an fixed offset.
+ * Nodes are copied with their ports and edges are copied if source and target were copied as well.
+ */
 @injectable()
-export class CopyPaste implements KeyListener {
+export class CopyPasteFeature implements KeyListener {
     private copyElements: SModelElementImpl[] = [];
 
     constructor(
         @inject(DynamicChildrenProcessor) private readonly dynamicChildrenProcessor: DynamicChildrenProcessor,
+        @inject(TYPES.IModelFactory) private readonly modelFactory: IModelFactory,
     ) {}
 
     keyUp(_element: SModelElementImpl, _event: KeyboardEvent): Action[] {
@@ -35,29 +47,118 @@ export class CopyPaste implements KeyListener {
         return [];
     }
 
+    /**
+     * Copy all selected elements into the "clipboard" (the internal element array)
+     */
     private copy(root: SModelRootImpl): Action[] {
-        this.copyElements = [];
+        this.copyElements = []; // Clear the clipboard
 
+        // Find selected elements
         root.index
             .all()
             .filter((element) => isSelected(element))
-            .filter((element) => element instanceof SNodeImpl) // only copy nodes for now
             .forEach((e) => this.copyElements.push(e));
 
         return [];
     }
 
+    /**
+     * Pastes elements by creating new elements and copying the properties of the copied elements.
+     */
     private paste(root: SModelRootImpl): Action[] {
+        // This maps the element id of the copy source element to the
+        // id that the newly created copy target element has.
+        const copyElementIdMapping: Record<string, string> = {};
+
+        // Step 1: copy nodes and their ports
         this.copyElements.forEach((element) => {
-            element.id = generateRandomSprottyId();
-            // Regenerate the dynamic children with new ids, etc.
-            this.dynamicChildrenProcessor.processGraphChildren(element, "set");
+            if (!(element instanceof SNodeImpl)) {
+                return;
+            }
+
+            const schema = {
+                id: generateRandomSprottyId(),
+                type: element.type,
+                position: { x: element.position.x + 30, y: element.position.y + 30 },
+                size: { height: -1, width: -1 },
+                text: "",
+                labels: [],
+                ports: [],
+            } as DfdNode;
+
+            copyElementIdMapping[element.id] = schema.id;
+
+            if (element instanceof DfdNodeImpl) {
+                schema.text = element.text;
+                element.labels.forEach((label) => schema.labels.push(label));
+                element.ports.forEach((port) => {
+                    const portSchema = {
+                        type: port.type,
+                        id: generateRandomSprottyId(),
+                    } as SPort;
+
+                    copyElementIdMapping[port.id] = portSchema.id;
+
+                    if ("position" in port && port.position) {
+                        portSchema.position = { x: port.position.x, y: port.position.y };
+                    }
+
+                    schema.ports.push(portSchema);
+                });
+            }
+
+            // Generate dynamic sub elements
+            this.dynamicChildrenProcessor.processGraphChildren(schema, "set");
+
+            const newElement = this.modelFactory.createElement(schema);
+            root.add(newElement as SChildElementImpl);
         });
 
+        // Step 2: copy edges
+        // If the source and target element of an edge are copied, the edge can be copied as well.
+        // If only one of them is copied, the edge is not copied.
         this.copyElements.forEach((element) => {
-            root.add(element as SChildElementImpl);
+            if (!(element instanceof SEdgeImpl)) {
+                return;
+            }
+
+            const newSourceId = copyElementIdMapping[element.sourceId];
+            const newTargetId = copyElementIdMapping[element.targetId];
+
+            console.log("edge", newSourceId, newTargetId, element);
+
+            if (!newSourceId || !newTargetId) {
+                // Not both source and target are copied, ignore this edge
+                return;
+            }
+
+            const schema = {
+                id: generateRandomSprottyId(),
+                type: element.type,
+                sourceId: newSourceId,
+                targetId: newTargetId,
+            } as ArrowEdge;
+            copyElementIdMapping[element.id] = schema.id;
+
+            if (element instanceof ArrowEdgeImpl) {
+                schema.text = element.editableLabel?.text ?? "";
+            }
+
+            // Generate dynamic sub elements (the edge label)
+            this.dynamicChildrenProcessor.processGraphChildren(schema, "set");
+
+            const newElement = this.modelFactory.createElement(schema);
+            root.add(newElement as SChildElementImpl);
         });
 
-        return [CommitModelAction.create()];
+        return [
+            CommitModelAction.create(),
+            SelectAction.create({
+                // Select newly created elements
+                selectedElementsIDs: Object.values(copyElementIdMapping),
+                // Deselect all old elements that were used as a source for the copy
+                deselectedElementsIDs: Object.keys(copyElementIdMapping),
+            }),
+        ];
     }
 }

--- a/src/common/copyPaste.ts
+++ b/src/common/copyPaste.ts
@@ -1,0 +1,63 @@
+import {
+    CommitModelAction,
+    KeyListener,
+    SChildElementImpl,
+    SModelElementImpl,
+    SModelRootImpl,
+    SNodeImpl,
+    isSelected,
+} from "sprotty";
+import { Action, CreateElementAction } from "sprotty-protocol";
+import { matchesKeystroke } from "sprotty/lib/utils/keyboard";
+import { generateRandomSprottyId } from "../utils";
+import { DynamicChildrenProcessor } from "../features/dfdElements/dynamicChildren";
+import { injectable, inject } from "inversify";
+
+@injectable()
+export class CopyPaste implements KeyListener {
+    private copyElements: SModelElementImpl[] = [];
+
+    constructor(
+        @inject(DynamicChildrenProcessor) private readonly dynamicChildrenProcessor: DynamicChildrenProcessor,
+    ) {}
+
+    keyUp(_element: SModelElementImpl, _event: KeyboardEvent): Action[] {
+        return [];
+    }
+
+    keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
+        if (matchesKeystroke(event, "KeyC", "ctrl")) {
+            return this.copy(element.root);
+        } else if (matchesKeystroke(event, "KeyV", "ctrl")) {
+            return this.paste(element.root);
+        }
+
+        return [];
+    }
+
+    private copy(root: SModelRootImpl): Action[] {
+        this.copyElements = [];
+
+        root.index
+            .all()
+            .filter((element) => isSelected(element))
+            .filter((element) => element instanceof SNodeImpl) // only copy nodes for now
+            .forEach((e) => this.copyElements.push(e));
+
+        return [];
+    }
+
+    private paste(root: SModelRootImpl): Action[] {
+        this.copyElements.forEach((element) => {
+            element.id = generateRandomSprottyId();
+            // Regenerate the dynamic children with new ids, etc.
+            this.dynamicChildrenProcessor.processGraphChildren(element, "set");
+        });
+
+        this.copyElements.forEach((element) => {
+            root.add(element as SChildElementImpl);
+        });
+
+        return [CommitModelAction.create()];
+    }
+}

--- a/src/common/di.config.ts
+++ b/src/common/di.config.ts
@@ -16,13 +16,10 @@ import { DeleteKeyListener } from "./deleteKeyListener";
 import { EDITOR_TYPES } from "../utils";
 import { DynamicChildrenProcessor } from "../features/dfdElements/dynamicChildren";
 import { FitToScreenKeyListener as CenterDiagramKeyListener } from "./fitToScreenKeyListener";
-import { CopyPasteFeature, PasteClipboardCommand } from "./copyPaste";
 
 import "./commonStyling.css";
 
 export const dfdCommonModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    const context = { bind, unbind, isBound, rebind };
-
     bind(ServerCommandPaletteActionProvider).toSelf().inSingletonScope();
     bind(TYPES.ICommandPaletteActionProvider).toService(ServerCommandPaletteActionProvider);
 
@@ -30,9 +27,6 @@ export const dfdCommonModule = new ContainerModule((bind, unbind, isBound, rebin
     bind(TYPES.KeyListener).toService(DeleteKeyListener);
     bind(CenterDiagramKeyListener).toSelf().inSingletonScope();
     rebind(CenterKeyboardListener).toService(CenterDiagramKeyListener);
-
-    bind(TYPES.KeyListener).to(CopyPasteFeature).inSingletonScope();
-    configureCommand(context, PasteClipboardCommand);
 
     bind(HelpUI).toSelf().inSingletonScope();
     bind(TYPES.IUIExtension).toService(HelpUI);
@@ -45,8 +39,12 @@ export const dfdCommonModule = new ContainerModule((bind, unbind, isBound, rebin
     bind(DynamicChildrenProcessor).toSelf().inSingletonScope();
 
     // For some reason the CreateElementAction and Command exist but in no sprotty module is the command registered, so we need to do this here.
+    const context = { bind, unbind, isBound, rebind };
     configureCommand(context, CreateElementCommand);
 
+    // Configure zoom limits
+    // Without these you could zoom in/out to infinity by accident resulting in your diagram being "gone".
+    // You can still get back to the diagram using the fit to screen action but these zoom limits prevents this from happening in the most cases.
     configureViewerOptions(context, {
         zoomLimits: { min: 0.05, max: 20 },
     });

--- a/src/common/di.config.ts
+++ b/src/common/di.config.ts
@@ -18,6 +18,7 @@ import { DynamicChildrenProcessor } from "../features/dfdElements/dynamicChildre
 import { FitToScreenKeyListener as CenterDiagramKeyListener } from "./fitToScreenKeyListener";
 
 import "./commonStyling.css";
+import { CopyPaste } from "./copyPaste";
 
 export const dfdCommonModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(ServerCommandPaletteActionProvider).toSelf().inSingletonScope();
@@ -27,6 +28,8 @@ export const dfdCommonModule = new ContainerModule((bind, unbind, isBound, rebin
     bind(TYPES.KeyListener).toService(DeleteKeyListener);
     bind(CenterDiagramKeyListener).toSelf().inSingletonScope();
     rebind(CenterKeyboardListener).toService(CenterDiagramKeyListener);
+
+    bind(TYPES.KeyListener).to(CopyPaste).inSingletonScope();
 
     bind(HelpUI).toSelf().inSingletonScope();
     bind(TYPES.IUIExtension).toService(HelpUI);

--- a/src/common/di.config.ts
+++ b/src/common/di.config.ts
@@ -16,11 +16,13 @@ import { DeleteKeyListener } from "./deleteKeyListener";
 import { EDITOR_TYPES } from "../utils";
 import { DynamicChildrenProcessor } from "../features/dfdElements/dynamicChildren";
 import { FitToScreenKeyListener as CenterDiagramKeyListener } from "./fitToScreenKeyListener";
+import { CopyPasteFeature, PasteClipboardCommand } from "./copyPaste";
 
 import "./commonStyling.css";
-import { CopyPasteFeature } from "./copyPaste";
 
 export const dfdCommonModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+    const context = { bind, unbind, isBound, rebind };
+
     bind(ServerCommandPaletteActionProvider).toSelf().inSingletonScope();
     bind(TYPES.ICommandPaletteActionProvider).toService(ServerCommandPaletteActionProvider);
 
@@ -30,6 +32,7 @@ export const dfdCommonModule = new ContainerModule((bind, unbind, isBound, rebin
     rebind(CenterKeyboardListener).toService(CenterDiagramKeyListener);
 
     bind(TYPES.KeyListener).to(CopyPasteFeature).inSingletonScope();
+    configureCommand(context, PasteClipboardCommand);
 
     bind(HelpUI).toSelf().inSingletonScope();
     bind(TYPES.IUIExtension).toService(HelpUI);
@@ -42,7 +45,6 @@ export const dfdCommonModule = new ContainerModule((bind, unbind, isBound, rebin
     bind(DynamicChildrenProcessor).toSelf().inSingletonScope();
 
     // For some reason the CreateElementAction and Command exist but in no sprotty module is the command registered, so we need to do this here.
-    const context = { bind, unbind, isBound, rebind };
     configureCommand(context, CreateElementCommand);
 
     configureViewerOptions(context, {

--- a/src/common/di.config.ts
+++ b/src/common/di.config.ts
@@ -18,7 +18,7 @@ import { DynamicChildrenProcessor } from "../features/dfdElements/dynamicChildre
 import { FitToScreenKeyListener as CenterDiagramKeyListener } from "./fitToScreenKeyListener";
 
 import "./commonStyling.css";
-import { CopyPaste } from "./copyPaste";
+import { CopyPasteFeature } from "./copyPaste";
 
 export const dfdCommonModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(ServerCommandPaletteActionProvider).toSelf().inSingletonScope();
@@ -29,7 +29,7 @@ export const dfdCommonModule = new ContainerModule((bind, unbind, isBound, rebin
     bind(CenterDiagramKeyListener).toSelf().inSingletonScope();
     rebind(CenterKeyboardListener).toService(CenterDiagramKeyListener);
 
-    bind(TYPES.KeyListener).to(CopyPaste).inSingletonScope();
+    bind(TYPES.KeyListener).to(CopyPasteFeature).inSingletonScope();
 
     bind(HelpUI).toSelf().inSingletonScope();
     bind(TYPES.IUIExtension).toService(HelpUI);

--- a/src/common/helpUi.tsx
+++ b/src/common/helpUi.tsx
@@ -36,6 +36,8 @@ export class HelpUI extends AbstractUIExtension {
                     <p><kbd>CTRL</kbd>+<kbd>S</kbd>: Save diagram to json</p>
                     <p><kbd>CTRL</kbd>+<kbd>L</kbd>: Automatically layout diagram</p>
                     <p><kbd>CTRL</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd>: Fit diagram to screen</p>
+                    <p><kbd>CTRL</kbd>+<kbd>C</kbd>: Copy selected elements</p>
+                    <p><kbd>CTRL</kbd>+<kbd>V</kbd>: Paste previously copied elements</p>
                 </div>
             </div>
         `;

--- a/src/features/copyPaste/di.config.ts
+++ b/src/features/copyPaste/di.config.ts
@@ -1,0 +1,16 @@
+import { ContainerModule } from "inversify";
+import { TYPES, configureCommand } from "sprotty";
+import { CopyPasteKeyListener } from "./keyListener";
+import { PasteElementsCommand } from "./pasteCommand";
+
+/**
+ * This feature allows the user to copy and paste elements.
+ * When ctrl+c is pressed, all selected elements are copied into an internal array.
+ * When ctrl+v is pressed, all elements in the internal array are pasted with an fixed offset.
+ * Nodes are copied with their ports and edges are copied if source and target were copied as well.
+ */
+export const copyPasteModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+    const context = { bind, unbind, isBound, rebind };
+    bind(TYPES.KeyListener).to(CopyPasteKeyListener).inSingletonScope();
+    configureCommand(context, PasteElementsCommand);
+});

--- a/src/features/copyPaste/keyListener.ts
+++ b/src/features/copyPaste/keyListener.ts
@@ -1,0 +1,53 @@
+import { injectable } from "inversify";
+import { PasteElementsAction } from "./pasteCommand";
+import { CommitModelAction, KeyListener, SModelElementImpl, SModelRootImpl, isSelected } from "sprotty";
+import { Action } from "sprotty-protocol";
+import { matchesKeystroke } from "sprotty/lib/utils/keyboard";
+
+/**
+ * This class is responsible for listening to ctrl+c and ctrl+v events.
+ * On copy the selected elements are copied into an internal array.
+ * On paste the {@link PasteElementsAction} is executed to paste the elements.
+ * This is done inside a command, so that it can be undone/redone.
+ */
+@injectable()
+export class CopyPasteKeyListener implements KeyListener {
+    private copyElements: SModelElementImpl[] = [];
+
+    keyUp(_element: SModelElementImpl, _event: KeyboardEvent): Action[] {
+        return [];
+    }
+
+    keyDown(element: SModelElementImpl, event: KeyboardEvent): Action[] {
+        if (matchesKeystroke(event, "KeyC", "ctrl")) {
+            return this.copy(element.root);
+        } else if (matchesKeystroke(event, "KeyV", "ctrl")) {
+            return this.paste();
+        }
+
+        return [];
+    }
+
+    /**
+     * Copy all selected elements into the "clipboard" (the internal element array)
+     */
+    private copy(root: SModelRootImpl): Action[] {
+        this.copyElements = []; // Clear the clipboard
+
+        // Find selected elements
+        root.index
+            .all()
+            .filter((element) => isSelected(element))
+            .forEach((e) => this.copyElements.push(e));
+
+        return [];
+    }
+
+    /**
+     * Pastes elements by creating new elements and copying the properties of the copied elements.
+     * This is done inside a command, so that it can be undone/redone.
+     */
+    private paste(): Action[] {
+        return [PasteElementsAction.create(this.copyElements), CommitModelAction.create()];
+    }
+}

--- a/src/features/copyPaste/keyListener.ts
+++ b/src/features/copyPaste/keyListener.ts
@@ -1,6 +1,13 @@
-import { injectable } from "inversify";
+import { inject, injectable } from "inversify";
 import { PasteElementsAction } from "./pasteCommand";
-import { CommitModelAction, KeyListener, SModelElementImpl, SModelRootImpl, isSelected } from "sprotty";
+import {
+    CommitModelAction,
+    KeyListener,
+    MousePositionTracker,
+    SModelElementImpl,
+    SModelRootImpl,
+    isSelected,
+} from "sprotty";
 import { Action } from "sprotty-protocol";
 import { matchesKeystroke } from "sprotty/lib/utils/keyboard";
 
@@ -13,6 +20,8 @@ import { matchesKeystroke } from "sprotty/lib/utils/keyboard";
 @injectable()
 export class CopyPasteKeyListener implements KeyListener {
     private copyElements: SModelElementImpl[] = [];
+
+    constructor(@inject(MousePositionTracker) private readonly mousePositionTracker: MousePositionTracker) {}
 
     keyUp(_element: SModelElementImpl, _event: KeyboardEvent): Action[] {
         return [];
@@ -48,6 +57,7 @@ export class CopyPasteKeyListener implements KeyListener {
      * This is done inside a command, so that it can be undone/redone.
      */
     private paste(): Action[] {
-        return [PasteElementsAction.create(this.copyElements), CommitModelAction.create()];
+        const targetPosition = this.mousePositionTracker.lastPositionOnDiagram ?? { x: 0, y: 0 };
+        return [PasteElementsAction.create(this.copyElements, targetPosition), CommitModelAction.create()];
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { toolPaletteModule } from "./features/toolPalette/di.config";
 import { serializeModule } from "./features/serialize/di.config";
 import { LoadDefaultDiagramAction } from "./features/serialize/loadDefaultDiagram";
 import { dfdElementsModule } from "./features/dfdElements/di.config";
+import { copyPasteModule } from "./features/copyPaste/di.config";
 import { EDITOR_TYPES } from "./utils";
 
 import "sprotty/css/sprotty.css";
@@ -82,6 +83,7 @@ container.load(
     serializeModule,
     dfdLabelModule,
     toolPaletteModule,
+    copyPasteModule,
 );
 
 const dispatcher = container.get<ActionDispatcher>(TYPES.IActionDispatcher);


### PR DESCRIPTION
Allows copying selected elements using ctrl+c and later pasting of those elements using ctrl+v. Pasting is done at the current pointer position and can be undone/redone because it is implemented using a command.