### PR TITLE
Element creation preview

### DIFF
--- a/src/common/commonStyling.css
+++ b/src/common/commonStyling.css
@@ -8,7 +8,8 @@
 .accordion-content {
     display: grid;
     /* This transition is used when closing the accordion. Here the x direction should start slow and then end fast, thus ease-out */
-    transition: grid-template-rows 300ms ease,
+    transition:
+        grid-template-rows 300ms ease,
         /* ease-in animation: https://cubic-bezier.com/#.7,0,1,.6 */ grid-template-columns 300ms
             cubic-bezier(0.7, 0, 1, 0.6),
         padding-top 300ms ease;
@@ -23,7 +24,8 @@
     grid-template-columns: 1fr;
 
     /* This transition is used when opening the accordion. Here the x direction should start fast and then end slow, thus ease-in */
-    transition: grid-template-rows 300ms ease,
+    transition:
+        grid-template-rows 300ms ease,
         /* ease-out animation: https://cubic-bezier.com/#0,.7,.4,1 */ /* mirrored version of the curve above */
             grid-template-columns 300ms cubic-bezier(0, 0.7, 0.4, 1),
         padding-top 300ms ease;

--- a/src/common/helpUi.css
+++ b/src/common/helpUi.css
@@ -13,7 +13,9 @@ div.help-ui kbd {
 
     border-radius: 3px;
     border: 1px solid var(--color-foreground);
-    box-shadow: 0 1px 1px var(--color-foreground), 0 2px 0 0 var(--color-background) inset;
+    box-shadow:
+        0 1px 1px var(--color-foreground),
+        0 2px 0 0 var(--color-background) inset;
     display: inline-block;
     font-size: 0.85em;
     font-weight: 700;

--- a/src/features/dfdElements/edges.tsx
+++ b/src/features/dfdElements/edges.tsx
@@ -75,12 +75,12 @@ export class ArrowEdgeView extends PolylineEdgeViewWithGapsOnIntersections {
         const p2 = segments[segments.length - 1];
         const arrow = (
             <path
-                class-sprotty-edge={true}
                 class-arrow={true}
                 d="M 0.5,0 L 10,-4 L 10,4 Z"
                 transform={`rotate(${toDegrees(angleOfPoint({ x: p1.x - p2.x, y: p1.y - p2.y }))} ${p2.x} ${
                     p2.y
                 }) translate(${p2.x} ${p2.y})`}
+                style={{ opacity: edge.opacity.toString() }}
             />
         );
         additionals.push(arrow);
@@ -92,7 +92,7 @@ export class ArrowEdgeView extends PolylineEdgeViewWithGapsOnIntersections {
      * In contrast to the default implementation that we override here,
      * this implementation makes the edge line 10px shorter at the end to make space for the arrow without any overlap.
      */
-    protected renderLine(_edge: SEdgeImpl, segments: Point[], _context: RenderingContext, _args?: IViewArgs): VNode {
+    protected renderLine(edge: SEdgeImpl, segments: Point[], _context: RenderingContext, _args?: IViewArgs): VNode {
         const firstPoint = segments[0];
         let path = `M ${firstPoint.x},${firstPoint.y}`;
         for (let i = 1; i < segments.length; i++) {
@@ -115,7 +115,7 @@ export class ArrowEdgeView extends PolylineEdgeViewWithGapsOnIntersections {
         return (
             <g>
                 {/* This is the actual path being rendered */}
-                <path d={path} />
+                <path d={path} class-sprotty-edge={true} style={{ opacity: edge.opacity.toString() }} />
                 {/* This is a transparent path that is rendered on top of the actual path to make it easier to select the edge */}
                 <path d={path} class-select-path={true} />
             </g>

--- a/src/features/dfdElements/nodes.tsx
+++ b/src/features/dfdElements/nodes.tsx
@@ -165,7 +165,7 @@ export class StorageNodeView extends ShapeView {
         const leftPadding = StorageNodeImpl.LEFT_PADDING / 2;
 
         return (
-            <g class-sprotty-node={true} class-storage={true}>
+            <g class-sprotty-node={true} class-storage={true} style={{ opacity: node.opacity.toString() }}>
                 <rect x="0" y="0" width={width} height={height} />
                 <line x1={StorageNodeImpl.LEFT_PADDING} y1="0" x2={StorageNodeImpl.LEFT_PADDING} y2={height} />
                 {context.renderChildren(node, {
@@ -217,7 +217,7 @@ export class FunctionNodeView extends ShapeView {
         const r = FunctionNodeImpl.BORDER_RADIUS;
 
         return (
-            <g class-sprotty-node={true} class-function={true}>
+            <g class-sprotty-node={true} class-function={true} style={{ opacity: node.opacity.toString() }}>
                 <rect x="0" y="0" width={width} height={height} rx={r} ry={r} />
                 <line x1="0" y1={FunctionNodeImpl.TEXT_HEIGHT} x2={width} y2={FunctionNodeImpl.TEXT_HEIGHT} />
                 {context.renderChildren(node, {
@@ -263,7 +263,7 @@ export class IONodeView extends ShapeView {
         const { width, height } = node.bounds;
 
         return (
-            <g class-sprotty-node={true} class-io={true}>
+            <g class-sprotty-node={true} class-io={true} style={{ opacity: node.opacity.toString() }}>
                 <rect x="0" y="0" width={width} height={height} />
 
                 {context.renderChildren(node, {

--- a/src/features/dfdElements/ports.tsx
+++ b/src/features/dfdElements/ports.tsx
@@ -73,7 +73,7 @@ export class DfdInputPortView extends ShapeView {
         const { width, height } = node.bounds;
 
         return (
-            <g class-sprotty-port={true} class-selected={node.selected}>
+            <g class-sprotty-port={true} class-selected={node.selected} style={{ opacity: node.opacity.toString() }}>
                 <rect x="0" y="0" width={width} height={height} />
                 <text x={width / 2} y={height / 2} class-port-text={true}>
                     I
@@ -128,7 +128,7 @@ export class DfdOutputPortView extends ShapeView {
         const { width, height } = node.bounds;
 
         return (
-            <g class-sprotty-port={true} class-selected={node.selected}>
+            <g class-sprotty-port={true} class-selected={node.selected} style={{ opacity: node.opacity.toString() }}>
                 <rect x="0" y="0" width={width} height={height} />
                 <text x={width / 2} y={height / 2} class-port-text={true}>
                     O

--- a/src/features/toolPalette/creationTool.ts
+++ b/src/features/toolPalette/creationTool.ts
@@ -99,23 +99,7 @@ export abstract class CreationTool<S extends Schema, I extends Impl> extends Mou
             return [];
         }
 
-        // Calculate the position of the mouse in the graph
-
-        const calculateMousePosition = (axis: "x" | "y") => {
-            // Position of the top left viewport corner in the whole graph
-            const rootPosition = root.scroll[axis];
-            // Offset of the mouse position from the top left viewport corner in screen pixels
-            const screenOffset = axis === "x" ? event.offsetX : event.offsetY;
-            // Offset of the mouse position from the top left viewport corner in graph coordinates
-            const screenOffsetNormalized = screenOffset / root.zoom;
-
-            // Add position
-            return rootPosition + screenOffsetNormalized;
-        };
-        const newPosition = {
-            x: calculateMousePosition("x"),
-            y: calculateMousePosition("y"),
-        };
+        const newPosition = { ...this.calculateMousePosition(event) };
 
         if (this.element instanceof SEdgeImpl) {
             // Snap the edge target to the mouse position, if there is a target element.
@@ -169,6 +153,35 @@ export abstract class CreationTool<S extends Schema, I extends Impl> extends Mou
         return [
             CommitModelAction.create(), // Save to element ModelSource
         ];
+    }
+
+    /**
+     * Calculates the mouse position in graph coordinates.
+     */
+    protected calculateMousePosition(event: MouseEvent): Point {
+        const root = this.element?.root as SGraphImpl | undefined;
+        if (!root) {
+            return {
+                x: -Infinity,
+                y: -Infinity,
+            };
+        }
+
+        const calcPos = (axis: "x" | "y") => {
+            // Position of the top left viewport corner in the whole graph
+            const rootPosition = root.scroll[axis];
+            // Offset of the mouse position from the top left viewport corner in screen pixels
+            const screenOffset = axis === "x" ? event.offsetX : event.offsetY;
+            // Offset of the mouse position from the top left viewport corner in graph coordinates
+            const screenOffsetNormalized = screenOffset / root.zoom;
+
+            // Add position
+            return rootPosition + screenOffsetNormalized;
+        };
+        return {
+            x: calcPos("x"),
+            y: calcPos("y"),
+        };
     }
 }
 

--- a/src/features/toolPalette/creationTool.ts
+++ b/src/features/toolPalette/creationTool.ts
@@ -1,0 +1,207 @@
+import {
+    ActionDispatcher,
+    CommandExecutionContext,
+    CommandReturn,
+    CommandStack,
+    CommitModelAction,
+    ICommand,
+    IModelFactory,
+    ISnapper,
+    MouseListener,
+    MouseTool,
+    SChildElementImpl,
+    SEdgeImpl,
+    SGraphImpl,
+    SModelElementImpl,
+    SNodeImpl,
+    SPortImpl,
+    TYPES,
+} from "sprotty";
+import { DfdTool } from "./tool";
+import { inject, injectable } from "inversify";
+import { DynamicChildrenProcessor } from "../dfdElements/dynamicChildren";
+import { Action, Point, SEdge, SNode, SPort, getBasicType } from "sprotty-protocol";
+
+type Positionable = { position?: Point };
+type Schema = (SNode | SEdge | SPort) & Positionable;
+type Impl = SNodeImpl | SEdgeImpl | SPortImpl;
+
+@injectable()
+export abstract class CreationTool<S extends Schema, I extends Impl> extends MouseListener implements DfdTool {
+    protected element?: I;
+    protected readonly previewOpacity = 0.5;
+
+    constructor(
+        @inject(MouseTool) protected mouseTool: MouseTool,
+        @inject(DynamicChildrenProcessor) protected dynamicChildrenProcessor: DynamicChildrenProcessor,
+        @inject(TYPES.IModelFactory) protected modelFactory: IModelFactory,
+        @inject(TYPES.IActionDispatcher) protected actionDispatcher: ActionDispatcher,
+        @inject(TYPES.ICommandStack) protected commandStack: CommandStack,
+        @inject(TYPES.ISnapper) protected snapper: ISnapper,
+    ) {
+        super();
+    }
+
+    abstract createElementSchema(): S;
+
+    protected createElement(): I {
+        const schema = this.createElementSchema();
+        if (getBasicType(schema) === "node" || getBasicType(schema) === "port") {
+            // Move node/port to the top left corner of the graph.
+            // Otherwise it may be visible at the model origin till the first mouse move over the diagram.
+            // Only for nodes and ports. Edges don't have a given position
+            schema.position = {
+                x: -Infinity,
+                y: -Infinity,
+            };
+        }
+
+        // Create the element with the preview opacity to indicated it is not placed yet
+        schema.opacity = this.previewOpacity;
+
+        // Add any dynamically declared children to the node schema.
+        this.dynamicChildrenProcessor.processGraphChildren(schema, "set");
+
+        const element = this.modelFactory.createElement(schema) as I;
+        this.actionDispatcher.dispatch(AddElementToGraphAction.create(element));
+        return element;
+    }
+
+    enable(): void {
+        this.mouseTool.register(this);
+        this.element = this.createElement();
+    }
+
+    disable(): void {
+        this.mouseTool.deregister(this);
+
+        if (this.element) {
+            // Element is not placed yet but we're disabling the tool.
+            // This means the creation was cancelled and the element should be deleted.
+            // We revert the last action to do this, which added the element to the graph.
+            this.commandStack.undo();
+            this.element = undefined;
+        }
+    }
+
+    protected finishPlacingElement(): void {
+        if (this.element) {
+            // Make node fully visible
+            this.element.opacity = 1;
+            this.element = undefined; // Unset to prevent further actions
+        }
+        this.disable();
+    }
+
+    mouseMove(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
+        const root = this.findRoot(target);
+        if (!this.element || !root) {
+            return [];
+        }
+
+        if (this.element instanceof SEdgeImpl) {
+            // TODO: implement
+        } else {
+            // Adjust the position of the node/port so that it is centered on the cursor.
+            const { width, height } = this.element.bounds;
+            const adjust = (offset: number, size: number) => {
+                const mousePosition = offset / root.zoom;
+                if (this.element instanceof SNodeImpl) {
+                    // The element should be created to have its center at the mouse position.
+                    // Because of this, we need to adjust the position by half the size of the element.
+                    return mousePosition - size / 2;
+                } else {
+                    // For ports we can leave the position as is because the correction to center the element
+                    //  around the mouse pointer is done by the PortAwareSnapper
+                    return mousePosition;
+                }
+            };
+
+            const previousPosition = this.element.position;
+            const newPosition = {
+                x: root.scroll.x + adjust(event.offsetX, width),
+                y: root.scroll.y + adjust(event.offsetY, height),
+            };
+
+            if (this.element instanceof SPortImpl) {
+                // Port positions must be relative to the target node.
+                // So we need to convert the absolute graph position of the mouse
+                // to a position relative to the target node.
+                const parent = this.element.parent;
+                if (parent instanceof SNodeImpl) {
+                    newPosition.x -= parent.position.x;
+                    newPosition.y -= parent.position.y;
+                }
+            }
+
+            const newPositionSnapped = this.snapper.snap(newPosition, this.element);
+
+            if (!Point.equals(previousPosition, newPositionSnapped)) {
+                // Only update if the position after snapping has changed (aka the effective position).
+                this.element.position = newPositionSnapped;
+                // Trigger re-rendering of the node/port
+                this.commandStack.update(this.element.root);
+            }
+        }
+
+        return [];
+    }
+
+    mouseDown(_target: SModelElementImpl, event: MouseEvent): Action[] {
+        event.preventDefault(); // prevents additional click onto the newly created element
+
+        this.finishPlacingElement();
+
+        return [
+            CommitModelAction.create(), // Save to element ModelSource
+        ];
+    }
+
+    private findRoot(target: SModelElementImpl): SGraphImpl | undefined {
+        if (target instanceof SGraphImpl) {
+            return target;
+        } else if (target instanceof SChildElementImpl) {
+            return this.findRoot(target.parent);
+        } else {
+            return undefined;
+        }
+    }
+}
+
+/**
+ * Adds the given element to the graph at the root level.
+ */
+export interface AddElementToGraphAction extends Action {
+    kind: typeof AddElementToGraphAction.TYPE;
+    element: SChildElementImpl;
+}
+export namespace AddElementToGraphAction {
+    export const TYPE = "addElementToGraph";
+    export function create(element: SChildElementImpl): AddElementToGraphAction {
+        return {
+            kind: TYPE,
+            element,
+        };
+    }
+}
+
+@injectable()
+export class AddElementToGraphCommand implements ICommand {
+    public static readonly KIND = AddElementToGraphAction.TYPE;
+
+    constructor(@inject(TYPES.Action) private action: AddElementToGraphAction) {}
+
+    execute(context: CommandExecutionContext): CommandReturn {
+        context.root.add(this.action.element);
+        return context.root;
+    }
+
+    undo(context: CommandExecutionContext): CommandReturn {
+        this.action.element.parent.remove(this.action.element);
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): CommandReturn {
+        return this.execute(context);
+    }
+}

--- a/src/features/toolPalette/di.config.ts
+++ b/src/features/toolPalette/di.config.ts
@@ -1,13 +1,21 @@
 import { ContainerModule } from "inversify";
 import { EDITOR_TYPES } from "../../utils";
+import { DfdToolDisableKeyListener } from "./tool";
+import { AddElementToGraphCommand } from "./creationTool";
 import { EdgeCreationTool } from "./edgeCreationTool";
 import { NodeCreationTool } from "./nodeCreationTool";
-import { ToolPaletteUI } from "./toolPalette";
-import { CommitModelAction, TYPES, configureActionHandler, configureCommand } from "sprotty";
-import { DfdToolDisableKeyListener } from "./tool";
 import { PortCreationTool } from "./portCreationTool";
+import { ToolPaletteUI } from "./toolPalette";
 import { CreateSnappedElementCommand } from "./createSnappedElementCommand";
-import { AddElementToGraphCommand } from "./creationTool";
+import {
+    CommitModelAction,
+    EmptyView,
+    SNodeImpl,
+    TYPES,
+    configureActionHandler,
+    configureCommand,
+    configureModelElement,
+} from "sprotty";
 
 // This module contains an UI extension that adds a tool palette to the editor.
 // This tool palette allows the user to create new nodes and edges.
@@ -21,9 +29,11 @@ export const toolPaletteModule = new ContainerModule((bind, unbind, isBound, reb
     bind(DfdToolDisableKeyListener).toSelf().inSingletonScope();
     bind(TYPES.KeyListener).toService(DfdToolDisableKeyListener);
 
+    configureModelElement(context, "empty-node", SNodeImpl, EmptyView);
+    configureCommand(context, AddElementToGraphCommand);
+
     bind(NodeCreationTool).toSelf().inSingletonScope();
     bind(EDITOR_TYPES.DfdTool).toService(NodeCreationTool);
-    configureCommand(context, AddElementToGraphCommand);
 
     bind(EdgeCreationTool).toSelf().inSingletonScope();
     bind(EDITOR_TYPES.DfdTool).toService(EdgeCreationTool);

--- a/src/features/toolPalette/di.config.ts
+++ b/src/features/toolPalette/di.config.ts
@@ -1,12 +1,13 @@
 import { ContainerModule } from "inversify";
 import { EDITOR_TYPES } from "../../utils";
 import { EdgeCreationTool } from "./edgeCreationTool";
-import { AddElementToGraphCommand, NodeCreationTool } from "./nodeCreationTool";
+import { NodeCreationTool } from "./nodeCreationTool";
 import { ToolPaletteUI } from "./toolPalette";
 import { CommitModelAction, TYPES, configureActionHandler, configureCommand } from "sprotty";
 import { DfdToolDisableKeyListener } from "./tool";
 import { PortCreationTool } from "./portCreationTool";
 import { CreateSnappedElementCommand } from "./createSnappedElementCommand";
+import { AddElementToGraphCommand } from "./creationTool";
 
 // This module contains an UI extension that adds a tool palette to the editor.
 // This tool palette allows the user to create new nodes and edges.

--- a/src/features/toolPalette/di.config.ts
+++ b/src/features/toolPalette/di.config.ts
@@ -1,7 +1,7 @@
 import { ContainerModule } from "inversify";
 import { EDITOR_TYPES } from "../../utils";
 import { EdgeCreationTool } from "./edgeCreationTool";
-import { NodeCreationTool } from "./nodeCreationTool";
+import { AddElementToGraphCommand, NodeCreationTool } from "./nodeCreationTool";
 import { ToolPaletteUI } from "./toolPalette";
 import { CommitModelAction, TYPES, configureActionHandler, configureCommand } from "sprotty";
 import { DfdToolDisableKeyListener } from "./tool";
@@ -22,6 +22,7 @@ export const toolPaletteModule = new ContainerModule((bind, unbind, isBound, reb
 
     bind(NodeCreationTool).toSelf().inSingletonScope();
     bind(EDITOR_TYPES.DfdTool).toService(NodeCreationTool);
+    configureCommand(context, AddElementToGraphCommand);
 
     bind(EdgeCreationTool).toSelf().inSingletonScope();
     bind(EDITOR_TYPES.DfdTool).toService(EdgeCreationTool);

--- a/src/features/toolPalette/edgeCreationTool.ts
+++ b/src/features/toolPalette/edgeCreationTool.ts
@@ -7,7 +7,7 @@ import {
     SModelElementImpl,
     SParentElementImpl,
 } from "sprotty";
-import { Action, SEdge } from "sprotty-protocol";
+import { Action, SEdge, SNode } from "sprotty-protocol";
 import { generateRandomSprottyId } from "../../utils";
 import { CreationTool } from "./creationTool";
 
@@ -73,7 +73,8 @@ export class EdgeCreationTool extends CreationTool<SEdge, SEdgeImpl> {
                 this.edgeTargetElement = this.modelFactory.createElement({
                     id: generateRandomSprottyId(),
                     type: "empty-node",
-                });
+                    position: this.calculateMousePosition(event),
+                } as SNode);
                 // Add empty node to the graph and as a edge target
                 this.element.root.add(this.edgeTargetElement);
                 this.element.targetId = this.edgeTargetElement.id;

--- a/src/features/toolPalette/nodeCreationTool.ts
+++ b/src/features/toolPalette/nodeCreationTool.ts
@@ -1,193 +1,34 @@
-import { injectable, inject } from "inversify";
+import { injectable } from "inversify";
 import { generateRandomSprottyId } from "../../utils";
-import {
-    ActionDispatcher,
-    CommandExecutionContext,
-    CommandReturn,
-    CommandStack,
-    CommitModelAction,
-    ICommand,
-    IModelFactory,
-    ISnapper,
-    MouseListener,
-    MouseTool,
-    SChildElementImpl,
-    SGraphImpl,
-    SModelElementImpl,
-    SNodeImpl,
-    TYPES,
-} from "sprotty";
-import { Action, Point } from "sprotty-protocol";
-import { DynamicChildrenProcessor } from "../dfdElements/dynamicChildren";
-import { DfdTool } from "./tool";
+import { SNodeImpl } from "sprotty";
+import { SNode } from "sprotty-protocol";
+import { CreationTool } from "./creationTool";
 
 /**
  * Creates a node when the user clicks somewhere on the root graph.
- * The type and size of the node can be configured via the NodeMetadata.
+ * The type of the node can be set using the parameter in the enable function.
  * Automatically disables itself after creating a node.
  */
 @injectable()
-export class NodeCreationTool extends MouseListener implements DfdTool {
-    private node?: SNodeImpl;
+export class NodeCreationTool extends CreationTool<SNode, SNodeImpl> {
+    private nodeType: string = "node:storage";
 
-    constructor(
-        @inject(MouseTool) private mouseTool: MouseTool,
-        @inject(DynamicChildrenProcessor) private dynamicChildrenProcessor: DynamicChildrenProcessor,
-        @inject(TYPES.IModelFactory) private modelFactory: IModelFactory,
-        @inject(TYPES.IActionDispatcher) private actionDispatcher: ActionDispatcher,
-        @inject(TYPES.ICommandStack) private commandStack: CommandStack,
-        @inject(TYPES.ISnapper) private snapper: ISnapper,
-        private nodeType = "node:storage",
-    ) {
-        super();
-    }
-
-    /**
-     * Method to enable the tool and optionally select the type of node to be created.
-     * If no type is given the default type/previous set type is used.
-     */
-    enable(nodeType?: string) {
+    enable(nodeType?: string): void {
         if (nodeType) {
             this.nodeType = nodeType;
         }
-        this.node = this.createNode();
 
-        this.mouseTool.register(this);
+        super.enable();
     }
 
-    disable(): void {
-        this.mouseTool.deregister(this);
-
-        if (this.node) {
-            // Node is not placed yet but we're disabling the tool.
-            // This means the creation was cancelled and the node should be deleted.
-            // We revert the last action to do this, which added the node to the graph.
-            this.commandStack.undo();
-            this.node = undefined;
-        }
-    }
-
-    private createNode(): SNodeImpl {
+    createElementSchema(): SNode {
         const defaultText = this.nodeType.replace("node:", "");
-        // Capitalize first letter
         const defaultTextCapitalized = defaultText.charAt(0).toUpperCase() + defaultText.slice(1);
 
-        const nodeSchema = {
-            type: this.nodeType,
-            id: generateRandomSprottyId(),
-            text: defaultTextCapitalized,
-            opacity: 0.5,
-            position: {
-                x: -Infinity,
-                y: -Infinity,
-            },
-        };
-
-        // Add any dynamically declared children to the node schema.
-        this.dynamicChildrenProcessor.processGraphChildren(nodeSchema, "set");
-
-        const node = this.modelFactory.createElement(nodeSchema);
-        if (node instanceof SNodeImpl) {
-            this.actionDispatcher.dispatch(AddElementToGraphAction.create(node));
-            return node;
-        } else {
-            throw new Error("Created Node is not an instance of SNodeImpl");
-        }
-    }
-
-    mouseMove(target: SModelElementImpl, event: MouseEvent): Action[] {
-        const root = this.findRoot(target);
-        if (!this.node || !root) {
-            return [];
-        }
-
-        // Adjust the position of the node so that it is centered on the cursor.
-        const { width, height } = this.node.bounds;
-        const adjust = (offset: number, size: number) => {
-            return offset / root.zoom - size / 2;
-        };
-
-        const previousPosition = this.node.position;
-        const newPosition = this.snapper.snap(
-            {
-                x: root.scroll.x + adjust(event.offsetX, width),
-                y: root.scroll.y + adjust(event.offsetY, height),
-            },
-            this.node,
-        );
-
-        if (!Point.equals(previousPosition, newPosition)) {
-            // Only update if the position after snapping has changed (aka the effective position).
-            this.node.position = newPosition;
-            // Trigger re-rendering of the node
-            this.commandStack.update(this.node.root);
-        }
-
-        return [];
-    }
-
-    private findRoot(target: SModelElementImpl): SGraphImpl | undefined {
-        if (target instanceof SGraphImpl) {
-            return target;
-        } else if (target instanceof SChildElementImpl) {
-            return this.findRoot(target.parent);
-        } else {
-            return undefined;
-        }
-    }
-
-    override mouseDown(_target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
-        event.preventDefault(); // prevents additional click onto the newly created element
-
-        if (this.node) {
-            // Make node fully visible
-            this.node.opacity = 1;
-            this.node = undefined; // Unset to prevent further actions
-        }
-
-        // This tool is done and can be disabled. No other nodes should be created unless re-enabled.
-        this.disable();
-
-        return [
-            CommitModelAction.create(), // Save to ModelSource
-        ];
-    }
-}
-
-/**
- * Adds the given element to the graph at the root level.
- */
-export interface AddElementToGraphAction extends Action {
-    kind: typeof AddElementToGraphAction.TYPE;
-    element: SChildElementImpl;
-}
-export namespace AddElementToGraphAction {
-    export const TYPE = "addElementToGraph";
-    export function create(element: SChildElementImpl): AddElementToGraphAction {
         return {
-            kind: TYPE,
-            element,
-        };
-    }
-}
-
-@injectable()
-export class AddElementToGraphCommand implements ICommand {
-    public static readonly KIND = AddElementToGraphAction.TYPE;
-
-    constructor(@inject(TYPES.Action) private action: AddElementToGraphAction) {}
-
-    execute(context: CommandExecutionContext): CommandReturn {
-        context.root.add(this.action.element);
-        return context.root;
-    }
-
-    undo(context: CommandExecutionContext): CommandReturn {
-        context.root.remove(this.action.element);
-        return context.root;
-    }
-
-    redo(context: CommandExecutionContext): CommandReturn {
-        return this.execute(context);
+            id: generateRandomSprottyId(),
+            type: this.nodeType,
+            text: defaultTextCapitalized,
+        } as SNode;
     }
 }

--- a/src/features/toolPalette/nodeCreationTool.ts
+++ b/src/features/toolPalette/nodeCreationTool.ts
@@ -1,11 +1,25 @@
 import { injectable, inject } from "inversify";
 import { generateRandomSprottyId } from "../../utils";
-import { CommitModelAction, LocalModelSource, MouseListener, MouseTool, SGraphImpl, TYPES } from "sprotty";
-import { Action } from "sprotty-protocol";
-import { DfdNodeImpl, DfdNode } from "../dfdElements/nodes";
+import {
+    ActionDispatcher,
+    CommandExecutionContext,
+    CommandReturn,
+    CommandStack,
+    CommitModelAction,
+    ICommand,
+    IModelFactory,
+    ISnapper,
+    MouseListener,
+    MouseTool,
+    SChildElementImpl,
+    SGraphImpl,
+    SModelElementImpl,
+    SNodeImpl,
+    TYPES,
+} from "sprotty";
+import { Action, Point } from "sprotty-protocol";
 import { DynamicChildrenProcessor } from "../dfdElements/dynamicChildren";
 import { DfdTool } from "./tool";
-import { CreateSnappedElementAction } from "./createSnappedElementCommand";
 
 /**
  * Creates a node when the user clicks somewhere on the root graph.
@@ -14,10 +28,15 @@ import { CreateSnappedElementAction } from "./createSnappedElementCommand";
  */
 @injectable()
 export class NodeCreationTool extends MouseListener implements DfdTool {
+    private node?: SNodeImpl;
+
     constructor(
-        @inject(TYPES.ModelSource) protected modelSource: LocalModelSource,
-        @inject(MouseTool) protected mouseTool: MouseTool,
-        @inject(DynamicChildrenProcessor) protected dynamicChildrenProcessor: DynamicChildrenProcessor,
+        @inject(MouseTool) private mouseTool: MouseTool,
+        @inject(DynamicChildrenProcessor) private dynamicChildrenProcessor: DynamicChildrenProcessor,
+        @inject(TYPES.IModelFactory) private modelFactory: IModelFactory,
+        @inject(TYPES.IActionDispatcher) private actionDispatcher: ActionDispatcher,
+        @inject(TYPES.ICommandStack) private commandStack: CommandStack,
+        @inject(TYPES.ISnapper) private snapper: ISnapper,
         private nodeType = "node:storage",
     ) {
         super();
@@ -31,56 +50,144 @@ export class NodeCreationTool extends MouseListener implements DfdTool {
         if (nodeType) {
             this.nodeType = nodeType;
         }
+        this.node = this.createNode();
+
         this.mouseTool.register(this);
     }
 
     disable(): void {
         this.mouseTool.deregister(this);
+
+        if (this.node) {
+            // Node is not placed yet but we're disabling the tool.
+            // This means the creation was cancelled and the node should be deleted.
+            // We revert the last action to do this, which added the node to the graph.
+            this.commandStack.undo();
+            this.node = undefined;
+        }
     }
 
-    override mouseDown(target: SGraphImpl, event: MouseEvent): (Action | Promise<Action>)[] {
-        if (target.type !== "graph") {
-            // Clicked on some element. Do nothing.
-            // We only want to create a node when clicking on the root graph/background.
-            return [];
-        }
-
-        // Create node
-        let text = this.nodeType.replace("node:", "");
-        text = text.charAt(0).toUpperCase() + text.slice(1); // Capitalize first letter
+    private createNode(): SNodeImpl {
+        const defaultText = this.nodeType.replace("node:", "");
+        // Capitalize first letter
+        const defaultTextCapitalized = defaultText.charAt(0).toUpperCase() + defaultText.slice(1);
 
         const nodeSchema = {
             type: this.nodeType,
             id: generateRandomSprottyId(),
-            text: text,
+            text: defaultTextCapitalized,
+            opacity: 0.5,
             position: {
-                x: event.screenX,
-                y: event.screenY,
+                x: -Infinity,
+                y: -Infinity,
             },
-            size: {
-                width: -1,
-                height: -1,
-            },
-        } as DfdNode;
-
-        // Adjust the position of the node so that it is centered on the cursor.
-        const adjust = (offset: number, size: number) => {
-            return offset / target.zoom - size / 2;
-        };
-        nodeSchema.position = {
-            x: target.scroll.x + adjust(event.offsetX, DfdNodeImpl.DEFAULT_WIDTH),
-            y: target.scroll.y + adjust(event.offsetY, 30),
         };
 
         // Add any dynamically declared children to the node schema.
         this.dynamicChildrenProcessor.processGraphChildren(nodeSchema, "set");
 
+        const node = this.modelFactory.createElement(nodeSchema);
+        if (node instanceof SNodeImpl) {
+            this.actionDispatcher.dispatch(AddElementToGraphAction.create(node));
+            return node;
+        } else {
+            throw new Error("Created Node is not an instance of SNodeImpl");
+        }
+    }
+
+    mouseMove(target: SModelElementImpl, event: MouseEvent): Action[] {
+        const root = this.findRoot(target);
+        if (!this.node || !root) {
+            return [];
+        }
+
+        // Adjust the position of the node so that it is centered on the cursor.
+        const { width, height } = this.node.bounds;
+        const adjust = (offset: number, size: number) => {
+            return offset / root.zoom - size / 2;
+        };
+
+        const previousPosition = this.node.position;
+        const newPosition = this.snapper.snap(
+            {
+                x: root.scroll.x + adjust(event.offsetX, width),
+                y: root.scroll.y + adjust(event.offsetY, height),
+            },
+            this.node,
+        );
+
+        if (!Point.equals(previousPosition, newPosition)) {
+            // Only update if the position after snapping has changed (aka the effective position).
+            this.node.position = newPosition;
+            // Trigger re-rendering of the node
+            this.commandStack.update(this.node.root);
+        }
+
+        return [];
+    }
+
+    private findRoot(target: SModelElementImpl): SGraphImpl | undefined {
+        if (target instanceof SGraphImpl) {
+            return target;
+        } else if (target instanceof SChildElementImpl) {
+            return this.findRoot(target.parent);
+        } else {
+            return undefined;
+        }
+    }
+
+    override mouseDown(_target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
+        event.preventDefault(); // prevents additional click onto the newly created element
+
+        if (this.node) {
+            // Make node fully visible
+            this.node.opacity = 1;
+            this.node = undefined; // Unset to prevent further actions
+        }
+
         // This tool is done and can be disabled. No other nodes should be created unless re-enabled.
         this.disable();
 
         return [
-            CreateSnappedElementAction.create(nodeSchema, target.id), // Create node and snap it to grid
             CommitModelAction.create(), // Save to ModelSource
         ];
+    }
+}
+
+/**
+ * Adds the given element to the graph at the root level.
+ */
+export interface AddElementToGraphAction extends Action {
+    kind: typeof AddElementToGraphAction.TYPE;
+    element: SChildElementImpl;
+}
+export namespace AddElementToGraphAction {
+    export const TYPE = "addElementToGraph";
+    export function create(element: SChildElementImpl): AddElementToGraphAction {
+        return {
+            kind: TYPE,
+            element,
+        };
+    }
+}
+
+@injectable()
+export class AddElementToGraphCommand implements ICommand {
+    public static readonly KIND = AddElementToGraphAction.TYPE;
+
+    constructor(@inject(TYPES.Action) private action: AddElementToGraphAction) {}
+
+    execute(context: CommandExecutionContext): CommandReturn {
+        context.root.add(this.action.element);
+        return context.root;
+    }
+
+    undo(context: CommandExecutionContext): CommandReturn {
+        context.root.remove(this.action.element);
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): CommandReturn {
+        return this.execute(context);
     }
 }

--- a/src/features/toolPalette/portCreationTool.ts
+++ b/src/features/toolPalette/portCreationTool.ts
@@ -1,5 +1,5 @@
 import { injectable } from "inversify";
-import { SChildElementImpl, SModelElementImpl, SPortImpl, SShapeElementImpl } from "sprotty";
+import { CommitModelAction, SChildElementImpl, SModelElementImpl, SPortImpl, SShapeElementImpl } from "sprotty";
 import { Action, SPort } from "sprotty-protocol";
 import { generateRandomSprottyId } from "../../utils";
 import { CreationTool } from "./creationTool";
@@ -54,7 +54,13 @@ export class PortCreationTool extends CreationTool<SPort, SPortImpl> {
     }
 
     mouseDown(target: SModelElementImpl, event: MouseEvent): Action[] {
-        // TODO: cancel addition of port if not inside a node right now
+        if (this.element?.parent === target.root) {
+            this.disable();
+            // Run some action to re-render the tool palette ui
+            // showing that the tool is disabled
+            return [CommitModelAction.create()];
+        }
+
         return super.mouseDown(target, event);
     }
 

--- a/src/features/toolPalette/portCreationTool.ts
+++ b/src/features/toolPalette/portCreationTool.ts
@@ -1,36 +1,64 @@
-import { inject, injectable } from "inversify";
-import { CommitModelAction, MouseListener, MouseTool, SChildElementImpl, SGraphImpl, SShapeElementImpl } from "sprotty";
-import { DfdTool } from "./tool";
-import { Action, SPort, SelectAction } from "sprotty-protocol";
+import { injectable } from "inversify";
+import { SChildElementImpl, SModelElementImpl, SPortImpl, SShapeElementImpl } from "sprotty";
+import { Action, SPort } from "sprotty-protocol";
 import { generateRandomSprottyId } from "../../utils";
-import { CreateSnappedElementAction } from "./createSnappedElementCommand";
+import { CreationTool } from "./creationTool";
 
 @injectable()
-export class PortCreationTool extends MouseListener implements DfdTool {
+export class PortCreationTool extends CreationTool<SPort, SPortImpl> {
     private portType: string = "port:dfd-input";
 
-    constructor(@inject(MouseTool) protected mouseTool: MouseTool) {
-        super();
-    }
-
-    enable(portType?: string) {
+    enable(portType?: string): void {
         if (portType) {
             this.portType = portType;
         }
-        this.mouseTool.register(this);
+
+        super.enable();
     }
 
-    disable(): void {
-        this.mouseTool.deregister(this);
+    createElementSchema(): SPort {
+        return {
+            id: generateRandomSprottyId(),
+            type: this.portType,
+        };
     }
 
-    /**
-     * Find the node that the port should be created in.
-     * This is the node that the user clicked on.
-     * If the user clicked on a label or other element that is not a node, we need to find the node that contains this element.
-     * If no node is found, undefined is returned.
-     */
-    private findNodeElement(target: SShapeElementImpl): SShapeElementImpl | undefined {
+    mouseMove(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
+        if (!this.element) {
+            return [];
+        }
+
+        const currentParent = this.element.parent;
+        const targetNode = this.findNodeElement(target);
+
+        if (targetNode) {
+            // We're hovering over a node, add the port to the node (if not already)
+            if (currentParent !== targetNode && target instanceof SChildElementImpl) {
+                this.element.opacity = this.previewOpacity;
+                currentParent.remove(this.element);
+                target.add(this.element);
+                this.commandStack.update(this.element.root);
+            }
+        } else {
+            // We're not hovering over a node.
+            // Add the port to the root graph (if not already) and hide it.
+            if (currentParent !== target.root) {
+                this.element.opacity = 0;
+                currentParent.remove(this.element);
+                target.root.add(this.element);
+                this.commandStack.update(this.element.root);
+            }
+        }
+
+        return super.mouseMove(target, event);
+    }
+
+    mouseDown(target: SModelElementImpl, event: MouseEvent): Action[] {
+        // TODO: cancel addition of port if not inside a node right now
+        return super.mouseDown(target, event);
+    }
+
+    private findNodeElement(target: SModelElementImpl): SModelElementImpl | undefined {
         if (target.type.startsWith("node")) {
             return target;
         }
@@ -38,51 +66,5 @@ export class PortCreationTool extends MouseListener implements DfdTool {
             return this.findNodeElement(target.parent);
         }
         return undefined;
-    }
-
-    mouseDown(target: SShapeElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
-        const node = this.findNodeElement(target);
-        if (!node) {
-            // We need a node that the port can be created in.
-            // It usually cannot be found because the user clicked on the graph root.
-            return [];
-        }
-
-        const root = target.root as SGraphImpl;
-
-        // Position where the user clicked
-        const clickPosition = {
-            x: root.scroll.x + event.offsetX / root.zoom,
-            y: root.scroll.y + event.offsetY / root.zoom,
-        };
-
-        // Create port
-        const portSchema = {
-            type: this.portType,
-            id: generateRandomSprottyId(),
-            position: {
-                // This position is relative to the node that this port is created in.
-                // So we will need to calculate the difference between the click position and the node position.
-                x: clickPosition.x - node.position.x,
-                y: clickPosition.y - node.position.y,
-            },
-            size: {
-                width: -1,
-                height: -1,
-            },
-        } as SPort;
-
-        // This tool is done and can be disabled. No other ports should be created unless re-enabled.
-        this.disable();
-
-        return [
-            CreateSnappedElementAction.create(portSchema, node.id),
-            CommitModelAction.create(), // Save change to ModelSource
-            // Select the newly created port and deselect the node that has been selected because the user clicked on it to initiate the port creation.
-            SelectAction.create({
-                selectedElementsIDs: [portSchema.id],
-                deselectedElementsIDs: [node.id],
-            }),
-        ];
     }
 }


### PR DESCRIPTION
Draws previews shadows of the elements that are to be created.
For nodes and ports this is a shadow element which is snapped at the mouse position.

For edges the shadow preview element only gets visible after selecting a source element.
After that the source of the preview element is fixed and the target is at a pseudo element which snaps to the mouse pointer.