### PR TITLE
Properly implement fit to screen after diagram loading

### DIFF
--- a/src/features/serialize/load.ts
+++ b/src/features/serialize/load.ts
@@ -187,7 +187,10 @@ export class LoadDiagramCommand extends Command {
  * Captures all element ids and dispatches a FitToScreenAction.
  * Also performs auto layouting if there are unpositioned nodes.
  */
-export function postLoadActions(newRoot: SModelRootImpl | undefined, actionDispatcher: ActionDispatcher): void {
+export async function postLoadActions(
+    newRoot: SModelRootImpl | undefined,
+    actionDispatcher: ActionDispatcher,
+): Promise<void> {
     if (!newRoot) {
         return;
     }
@@ -197,10 +200,10 @@ export function postLoadActions(newRoot: SModelRootImpl | undefined, actionDispa
         .filter((child) => child instanceof SNodeImpl)
         .some((child) => isLocateable(child) && (child.position.x === 0 || child.position.y === 0));
     if (containsUnPositionedNodes) {
-        actionDispatcher.dispatch(LayoutModelAction.create());
+        await actionDispatcher.dispatch(LayoutModelAction.create());
     }
 
     // fit to screen is done after auto layouting because that may change the bounds of the diagram
     // requiring another fit to screen.
-    actionDispatcher.dispatch(createDefaultFitToScreenAction(newRoot, false));
+    await actionDispatcher.dispatch(createDefaultFitToScreenAction(newRoot, false));
 }

--- a/src/features/serialize/loadDefaultDiagram.ts
+++ b/src/features/serialize/loadDefaultDiagram.ts
@@ -13,7 +13,7 @@ import {
 import { Action } from "sprotty-protocol";
 import { LabelType, LabelTypeRegistry } from "../labels/labelTypeRegistry";
 import { DynamicChildrenProcessor } from "../dfdElements/dynamicChildren";
-import { postLoadActions } from "./load";
+import { LoadDiagramCommand, postLoadActions } from "./load";
 import defaultDiagramData from "./defaultDiagram.json";
 
 export interface LoadDefaultDiagramAction extends Action {
@@ -31,6 +31,8 @@ export namespace LoadDefaultDiagramAction {
 
 @injectable()
 export class LoadDefaultDiagramCommand extends Command {
+    readonly blockUntil = LoadDiagramCommand.loadBlockUntilFn;
+
     static readonly KIND = LoadDefaultDiagramAction.KIND;
     @inject(TYPES.ILogger)
     private readonly logger: ILogger = new NullLogger();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ const contextMap = new Map<string, { context: CanvasRenderingContext2D; cache: M
  * Because this operation requires interacting with the browser including styling etc.
  * this is rather expensive. Therefore the result is cached with the font and text as a cache key
  * The default width for empty text is 20px.
- * Big diagrams with hundereds of text elements (edges, nodes, labels) would not be possible without caching this operation.
+ * Big diagrams with hundreds of text elements (edges, nodes, labels) would not be possible without caching this operation.
  *
  * @param text the text you need the size for
  * @param font the font to use, defaults to "11pt sans-serif"


### PR DESCRIPTION
Closes #15
Implements a block to wait for the model to fully load before executing the fit to center command instead of having the ugly fixed 100ms wait.