### PR TITLE
Add optional node annotations and editor modes

### DIFF
--- a/src/common/customCommandStack.ts
+++ b/src/common/customCommandStack.ts
@@ -1,4 +1,13 @@
-import { BringToFrontCommand, CommandStack, HiddenCommand, ICommand, SelectCommand, SetViewportCommand } from "sprotty";
+import {
+    BringToFrontCommand,
+    CenterCommand,
+    CommandStack,
+    FitToScreenCommand,
+    HiddenCommand,
+    ICommand,
+    SelectCommand,
+    SetViewportCommand,
+} from "sprotty";
 
 /**
  * Custom command stack implementations that only pushes
@@ -18,7 +27,9 @@ export class DiagramModificationCommandStack extends CommandStack {
             command instanceof HiddenCommand ||
             command instanceof SelectCommand ||
             command instanceof SetViewportCommand ||
-            command instanceof BringToFrontCommand
+            command instanceof BringToFrontCommand ||
+            command instanceof FitToScreenCommand ||
+            command instanceof CenterCommand
         );
     }
 }

--- a/src/common/helpUi.tsx
+++ b/src/common/helpUi.tsx
@@ -21,7 +21,7 @@ export class HelpUI extends AbstractUIExtension {
             <input type="checkbox" id="accordion-state-help" class="accordion-state" hidden>
             <label id="help-ui-accordion-label" for="accordion-state-help">
                 <div class="accordion-button">
-                    Keyboard Shortcuts
+                    Keyboard Shortcuts | Help
                 </div>
             </label>
             <div class="accordion-content">

--- a/src/features/dfdElements/di.config.ts
+++ b/src/features/dfdElements/di.config.ts
@@ -19,7 +19,7 @@ import { AlwaysSnapPortsMoveMouseListener, ReSnapPortsAfterLabelChangeCommand, P
 import { OutputPortEditUIMouseListener, OutputPortEditUI, SetDfdOutputPortBehaviorCommand } from "./outputPortEditUi";
 import { DfdEditLabelValidator, DfdEditLabelValidatorDecorator } from "./editLabelValidator";
 import { PortBehaviorValidator } from "./outputPortBehaviorValidation";
-import { DfdNodeValidationResultUI, DfdNodeValidationResultUIMouseListener } from "./nodeValidationResultUi";
+import { DfdNodeAnnotationUI, DfdNodeAnnotationUIMouseListener } from "./nodeAnnotationUi";
 
 import "./elementStyles.css";
 
@@ -38,9 +38,9 @@ export const dfdElementsModule = new ContainerModule((bind, unbind, isBound, reb
     bind(TYPES.IEditLabelValidator).to(DfdEditLabelValidator).inSingletonScope();
     bind(TYPES.IEditLabelValidationDecorator).to(DfdEditLabelValidatorDecorator).inSingletonScope();
 
-    bind(DfdNodeValidationResultUIMouseListener).toSelf().inSingletonScope();
-    bind(TYPES.MouseListener).toService(DfdNodeValidationResultUIMouseListener);
-    bind(TYPES.IUIExtension).to(DfdNodeValidationResultUI).inSingletonScope();
+    bind(DfdNodeAnnotationUIMouseListener).toSelf().inSingletonScope();
+    bind(TYPES.MouseListener).toService(DfdNodeAnnotationUIMouseListener);
+    bind(TYPES.IUIExtension).to(DfdNodeAnnotationUI).inSingletonScope();
 
     configureModelElement(context, "graph", SGraphImpl, SGraphView);
     configureModelElement(context, "node:storage", StorageNodeImpl, StorageNodeView);

--- a/src/features/dfdElements/di.config.ts
+++ b/src/features/dfdElements/di.config.ts
@@ -19,6 +19,7 @@ import { AlwaysSnapPortsMoveMouseListener, ReSnapPortsAfterLabelChangeCommand, P
 import { OutputPortEditUIMouseListener, OutputPortEditUI, SetDfdOutputPortBehaviorCommand } from "./outputPortEditUi";
 import { DfdEditLabelValidator, DfdEditLabelValidatorDecorator } from "./editLabelValidator";
 import { PortBehaviorValidator } from "./outputPortBehaviorValidation";
+import { DfdNodeValidationResultUI, DfdNodeValidationResultUIMouseListener } from "./nodeValidationResultUi";
 
 import "./elementStyles.css";
 
@@ -36,6 +37,10 @@ export const dfdElementsModule = new ContainerModule((bind, unbind, isBound, reb
 
     bind(TYPES.IEditLabelValidator).to(DfdEditLabelValidator).inSingletonScope();
     bind(TYPES.IEditLabelValidationDecorator).to(DfdEditLabelValidatorDecorator).inSingletonScope();
+
+    bind(DfdNodeValidationResultUIMouseListener).toSelf().inSingletonScope();
+    bind(TYPES.MouseListener).toService(DfdNodeValidationResultUIMouseListener);
+    bind(TYPES.IUIExtension).to(DfdNodeValidationResultUI).inSingletonScope();
 
     configureModelElement(context, "graph", SGraphImpl, SGraphView);
     configureModelElement(context, "node:storage", StorageNodeImpl, StorageNodeView);

--- a/src/features/dfdElements/elementStyles.css
+++ b/src/features/dfdElements/elementStyles.css
@@ -1,7 +1,7 @@
-/* This file contains styling for the node views defined in nodes.tsx and edge.tsx */
+/* This file contains styling for the node views defined in nodes.tsx, edge.tsx and ports.tsx */
 
 /* sprotty-* classes are automatically added by sprotty and the other ones
-   are added in the definition inside nodes.tsx and edge.tsx */
+   are added in the definition inside nodes.tsx, edge.tsx and ports.tsx */
 
 /* Nodes */
 

--- a/src/features/dfdElements/elementStyles.css
+++ b/src/features/dfdElements/elementStyles.css
@@ -73,7 +73,7 @@
 
 .sprotty-port rect {
     stroke: var(--color-foreground);
-    fill: var(--color-background);
+    fill: color-mix(in srgb, var(--color-primary), var(--color-background) 25%);
     stroke-width: 0.5;
 }
 

--- a/src/features/dfdElements/elementStyles.css
+++ b/src/features/dfdElements/elementStyles.css
@@ -16,7 +16,10 @@
        See https://stackoverflow.com/questions/17893823/how-to-pass-parameters-to-css-classes */
     stroke: var(--color, var(--color-foreground));
     stroke-width: 1;
-    fill: transparent;
+    /* Background fill of the node.
+       When --color is unset this is just --color-primary.
+       If this node is annotated and --color is set, it will be included in the color mix. */
+    fill: color-mix(in srgb, var(--color-primary), var(--color, transparent) 25%);
 }
 
 .sprotty-node .node-label text {
@@ -47,7 +50,8 @@
    This makes it easier to select the edge with the mouse. */
 .sprotty-edge path.select-path {
     stroke: transparent;
-    stroke-width: 8; /* make the "invisible hitbox" 8 pixels wide. This is the same width as the arrow head */
+    /* make the "invisible hitbox" 8 pixels wide. This is the same width as the arrow head */
+    stroke-width: 8;
 }
 
 .sprotty-edge .arrow {

--- a/src/features/dfdElements/elementStyles.css
+++ b/src/features/dfdElements/elementStyles.css
@@ -8,7 +8,13 @@
 .sprotty-node rect,
 .sprotty-node line,
 .sprotty-node circle {
-    stroke: var(--color-foreground);
+    /* stroke color defaults to be the foreground color of the theme.
+       Alternatively it can be overwritten by setting the --color variable
+       As a inline style attribute for the specific node.
+       Used as a highlighter to mark nodes with errors.
+       This is essentially a "optional parameter" to this css rule.
+       See https://stackoverflow.com/questions/17893823/how-to-pass-parameters-to-css-classes */
+    stroke: var(--color, var(--color-foreground));
     stroke-width: 1;
     fill: transparent;
 }

--- a/src/features/dfdElements/nodeAnnotationUi.css
+++ b/src/features/dfdElements/nodeAnnotationUi.css
@@ -1,14 +1,14 @@
-.dfd-node-validation-result-ui {
+.dfd-node-annotation-ui {
     /* don't break lines into multiple when they don't fit on screen.
        Just let the popup clip outside the screen when there is not enough space and let the
        user move the popup at a position where the text is fully visible */
     white-space: nowrap;
 }
 
-.dfd-node-validation-result-ui p {
+.dfd-node-annotation-ui p {
     margin: 12px;
 }
 
-.dfd-node-validation-result-ui i.fa {
+.dfd-node-annotation-ui i.fa {
     margin-right: 5px;
 }

--- a/src/features/dfdElements/nodeValidationResultUi.css
+++ b/src/features/dfdElements/nodeValidationResultUi.css
@@ -1,0 +1,14 @@
+.dfd-node-validation-result-ui {
+    /* don't break lines into multiple when they don't fit on screen.
+       Just let the popup clip outside the screen when there is not enough space and let the
+       user move the popup at a position where the text is fully visible */
+    white-space: nowrap;
+}
+
+.dfd-node-validation-result-ui p {
+    margin: 12px;
+}
+
+.dfd-node-validation-result-ui i.fa {
+    margin-right: 5px;
+}

--- a/src/features/dfdElements/nodeValidationResultUi.ts
+++ b/src/features/dfdElements/nodeValidationResultUi.ts
@@ -154,7 +154,7 @@ export class DfdNodeValidationResultUI extends AbstractUIExtension {
         }
 
         const { message, fontAwesomeIcon } = node.validationResult;
-        this.validationParagraph.innerText = `Error: ${message}`;
+        this.validationParagraph.innerText = message;
 
         if (fontAwesomeIcon) {
             const icon = document.createElement("i");

--- a/src/features/dfdElements/nodeValidationResultUi.ts
+++ b/src/features/dfdElements/nodeValidationResultUi.ts
@@ -1,0 +1,165 @@
+import { inject, injectable } from "inversify";
+import {
+    AbstractUIExtension,
+    IActionDispatcher,
+    MouseListener,
+    SChildElementImpl,
+    SModelElementImpl,
+    SModelRootImpl,
+    SetUIExtensionVisibilityAction,
+    TYPES,
+} from "sprotty";
+import { Action } from "sprotty-protocol";
+import { DfdNodeImpl } from "./nodes";
+
+import "@fortawesome/fontawesome-free/css/all.min.css";
+import "./nodeValidationResultUi.css";
+
+export class DfdNodeValidationResultUIMouseListener extends MouseListener {
+    private stillTimeout: NodeJS.Timeout | undefined;
+    private lastPosition = { x: 0, y: 0 };
+
+    constructor(@inject(TYPES.IActionDispatcher) private readonly actionDispatcher: IActionDispatcher) {
+        super();
+    }
+
+    mouseMove(target: SModelElementImpl, event: MouseEvent): Action[] {
+        const dfdNode = this.findDfdNode(target);
+        if (!dfdNode) {
+            if (this.stillTimeout) {
+                clearTimeout(this.stillTimeout);
+                this.stillTimeout = undefined;
+            }
+            return [];
+        }
+
+        if (this.lastPosition.x !== event.clientX || this.lastPosition.y !== event.clientY) {
+            this.lastPosition = { x: event.clientX, y: event.clientY };
+            // Mouse has moved, so we reset the timeout
+            if (this.stillTimeout) {
+                clearTimeout(this.stillTimeout);
+            }
+            this.stillTimeout = setTimeout(() => {
+                // When the mouse has not moved for 500ms, we show the popup
+                this.stillTimeout = undefined;
+
+                if (dfdNode.opacity !== 1) {
+                    // Only show when opacity is 1.
+                    // The opacity is not 1 when the node is currently being created but has not been
+                    // placed yet.
+                    // In this case we don't want to show the popup
+                    // and interfere with the creation process.
+                    return;
+                }
+
+                this.showPopup(dfdNode);
+            }, 500);
+        }
+
+        return [];
+    }
+
+    private findDfdNode(currentNode: SModelElementImpl): DfdNodeImpl | undefined {
+        if (currentNode instanceof DfdNodeImpl) {
+            return currentNode;
+        } else if (currentNode instanceof SChildElementImpl && currentNode.parent) {
+            return this.findDfdNode(currentNode.parent);
+        } else {
+            return undefined;
+        }
+    }
+
+    private showPopup(target: DfdNodeImpl): void {
+        if (!target.validationResult) {
+            // no validation errors, all fine. No need to show the popup.
+            return;
+        }
+
+        this.actionDispatcher.dispatch(
+            SetUIExtensionVisibilityAction.create({
+                extensionId: DfdNodeValidationResultUI.ID,
+                visible: true,
+                contextElementsId: [target.id],
+            }),
+        );
+    }
+
+    public getMousePosition(): { x: number; y: number } {
+        return this.lastPosition;
+    }
+}
+
+@injectable()
+export class DfdNodeValidationResultUI extends AbstractUIExtension {
+    static readonly ID = "dfd-node-validation-result-ui";
+
+    private readonly validationParagraph = document.createElement("p") as HTMLParagraphElement;
+
+    constructor(
+        @inject(DfdNodeValidationResultUIMouseListener)
+        private readonly mouseListener: DfdNodeValidationResultUIMouseListener,
+    ) {
+        super();
+    }
+
+    id(): string {
+        return DfdNodeValidationResultUI.ID;
+    }
+
+    containerClass(): string {
+        return this.id();
+    }
+
+    protected override initializeContents(containerElement: HTMLElement): void {
+        containerElement.classList.add("ui-float");
+        containerElement.appendChild(this.validationParagraph);
+
+        containerElement.addEventListener("mouseleave", () => {
+            this.hide();
+        });
+    }
+
+    protected override onBeforeShow(
+        containerElement: HTMLElement,
+        root: Readonly<SModelRootImpl>,
+        ...contextElementIds: string[]
+    ): void {
+        if (contextElementIds.length !== 1) {
+            this.validationParagraph.innerText =
+                "UI Error: Expected exactly one context element id, but got " + contextElementIds.length;
+            return;
+        }
+
+        const node = root.index.getById(contextElementIds[0]);
+        if (!(node instanceof DfdNodeImpl)) {
+            this.validationParagraph.innerText =
+                "UI Error: Expected context element to be a DfdNodeImpl, but got " + node;
+            return;
+        }
+
+        // Clear previous content
+        this.validationParagraph.innerHTML = "";
+
+        // 2 offset to ensure the mouse is inside the popup when showing it.
+        // Otherwise it would be on the node instead of the popup because of the rounded corners.
+        // The cursor should be inside the popup when opening it for the closing
+        // using the mouseleave event to work correctly.
+        const mousePosition = this.mouseListener.getMousePosition();
+        containerElement.style.left = `${mousePosition.x - 2}px`;
+        containerElement.style.top = `${mousePosition.y - 2}px`;
+
+        if (!node.validationResult) {
+            this.validationParagraph.innerText = "No errors";
+            return;
+        }
+
+        const { message, fontAwesomeIcon } = node.validationResult;
+        this.validationParagraph.innerText = `Error: ${message}`;
+
+        if (fontAwesomeIcon) {
+            const icon = document.createElement("i");
+            icon.classList.add("fa", `fa-${fontAwesomeIcon}`);
+            this.validationParagraph.prepend(icon);
+        }
+    }
+}

--- a/src/features/dfdElements/nodes.tsx
+++ b/src/features/dfdElements/nodes.tsx
@@ -10,7 +10,7 @@ import {
 } from "sprotty";
 import { SNode, SLabel, Bounds, SModelElement, SPort } from "sprotty-protocol";
 import { inject, injectable, optional } from "inversify";
-import { VNode } from "snabbdom";
+import { VNode, VNodeStyle } from "snabbdom";
 import { LabelAssignment } from "../labels/labelTypeRegistry";
 import { DynamicChildrenNode } from "./dynamicChildren";
 import { containsDfdLabelFeature } from "../labels/elementFeature";
@@ -132,6 +132,22 @@ export abstract class DfdNodeImpl extends DynamicChildrenNode implements WithEdi
             .filter(edgePredicate)
             .map((edge) => edge.editableLabel?.text ?? "");
     }
+
+    /**
+     * Generates the per-node inline style object for the view.
+     * Contains the opacity and the color of the node that may be set by the validation result.
+     */
+    geViewStyleObject(): VNodeStyle {
+        const style: VNodeStyle = {
+            opacity: this.opacity.toString(),
+        };
+
+        if (this.validationResult?.color) {
+            style["--color"] = this.validationResult.color;
+        }
+
+        return style;
+    }
 }
 
 @injectable()
@@ -173,8 +189,8 @@ export class StorageNodeView extends ShapeView {
         const leftPadding = StorageNodeImpl.LEFT_PADDING / 2;
 
         return (
-            <g class-sprotty-node={true} class-storage={true} style={{ opacity: node.opacity.toString() }}>
-                <rect x="0" y="0" width={width} height={height} />
+            <g class-sprotty-node={true} class-storage={true} style={node.geViewStyleObject()}>
+                <rect x="0" y="0" width={width} height={height} stroke="red" />
                 <line x1={StorageNodeImpl.LEFT_PADDING} y1="0" x2={StorageNodeImpl.LEFT_PADDING} y2={height} />
                 {context.renderChildren(node, {
                     xPosition: width / 2 + leftPadding,
@@ -225,7 +241,7 @@ export class FunctionNodeView extends ShapeView {
         const r = FunctionNodeImpl.BORDER_RADIUS;
 
         return (
-            <g class-sprotty-node={true} class-function={true} style={{ opacity: node.opacity.toString() }}>
+            <g class-sprotty-node={true} class-function={true} style={node.geViewStyleObject()}>
                 <rect x="0" y="0" width={width} height={height} rx={r} ry={r} />
                 <line x1="0" y1={FunctionNodeImpl.TEXT_HEIGHT} x2={width} y2={FunctionNodeImpl.TEXT_HEIGHT} />
                 {context.renderChildren(node, {
@@ -271,7 +287,7 @@ export class IONodeView extends ShapeView {
         const { width, height } = node.bounds;
 
         return (
-            <g class-sprotty-node={true} class-io={true} style={{ opacity: node.opacity.toString() }}>
+            <g class-sprotty-node={true} class-io={true} style={node.geViewStyleObject()}>
                 <rect x="0" y="0" width={width} height={height} />
 
                 {context.renderChildren(node, {

--- a/src/features/dfdElements/nodes.tsx
+++ b/src/features/dfdElements/nodes.tsx
@@ -24,13 +24,13 @@ export interface DfdNode extends SNode {
     text: string;
     labels: LabelAssignment[];
     ports: SPort[];
-    validationResult?: DfdNodeValidationResult;
+    annotation?: DfdNodeAnnotation;
 }
 
-export interface DfdNodeValidationResult {
+export interface DfdNodeAnnotation {
     message: string;
     color?: string;
-    fontAwesomeIcon?: string;
+    icon?: string;
 }
 
 export abstract class DfdNodeImpl extends DynamicChildrenNode implements WithEditableLabel {
@@ -41,7 +41,7 @@ export abstract class DfdNodeImpl extends DynamicChildrenNode implements WithEdi
     text: string = "";
     labels: LabelAssignment[] = [];
     ports: SPort[] = [];
-    validationResult?: DfdNodeValidationResult;
+    annotation?: DfdNodeAnnotation;
 
     override setChildren(schema: DfdNode): void {
         const children: SModelElement[] = [
@@ -135,15 +135,15 @@ export abstract class DfdNodeImpl extends DynamicChildrenNode implements WithEdi
 
     /**
      * Generates the per-node inline style object for the view.
-     * Contains the opacity and the color of the node that may be set by the validation result.
+     * Contains the opacity and the color of the node that may be set by the annotation (if any).
      */
     geViewStyleObject(): VNodeStyle {
         const style: VNodeStyle = {
             opacity: this.opacity.toString(),
         };
 
-        if (this.validationResult?.color) {
-            style["--color"] = this.validationResult.color;
+        if (this.annotation?.color) {
+            style["--color"] = this.annotation.color;
         }
 
         return style;

--- a/src/features/dfdElements/nodes.tsx
+++ b/src/features/dfdElements/nodes.tsx
@@ -27,7 +27,7 @@ export interface DfdNode extends SNode {
     validationResult?: DfdNodeValidationResult;
 }
 
-interface DfdNodeValidationResult {
+export interface DfdNodeValidationResult {
     message: string;
     color?: string;
     fontAwesomeIcon?: string;

--- a/src/features/dfdElements/nodes.tsx
+++ b/src/features/dfdElements/nodes.tsx
@@ -24,6 +24,13 @@ export interface DfdNode extends SNode {
     text: string;
     labels: LabelAssignment[];
     ports: SPort[];
+    validationResult?: DfdNodeValidationResult;
+}
+
+interface DfdNodeValidationResult {
+    message: string;
+    color?: string;
+    fontAwesomeIcon?: string;
 }
 
 export abstract class DfdNodeImpl extends DynamicChildrenNode implements WithEditableLabel {
@@ -34,6 +41,7 @@ export abstract class DfdNodeImpl extends DynamicChildrenNode implements WithEdi
     text: string = "";
     labels: LabelAssignment[] = [];
     ports: SPort[] = [];
+    validationResult?: DfdNodeValidationResult;
 
     override setChildren(schema: DfdNode): void {
         const children: SModelElement[] = [

--- a/src/features/dfdElements/outputPortEditUi.ts
+++ b/src/features/dfdElements/outputPortEditUi.ts
@@ -29,6 +29,7 @@ import "monaco-editor/esm/vs/editor/contrib/inlineCompletions/browser/inlineComp
 
 import "./outputPortEditUi.css";
 import { LabelTypeRegistry } from "../labels/labelTypeRegistry";
+import { EditorModeController } from "../editorMode/editorModeController";
 
 /**
  * Detects when a dfd output port is double clicked and shows the OutputPortEditUI
@@ -354,6 +355,9 @@ export class OutputPortEditUI extends AbstractUIExtension {
         @inject(TYPES.DOMHelper) private domHelper: DOMHelper,
         @inject(PortBehaviorValidator) private validator: PortBehaviorValidator,
         @inject(LabelTypeRegistry) @optional() private labelTypeRegistry?: LabelTypeRegistry,
+        @inject(EditorModeController)
+        @optional()
+        private editorModeController?: EditorModeController,
     ) {
         super();
     }
@@ -419,6 +423,15 @@ export class OutputPortEditUI extends AbstractUIExtension {
                 this.hide();
             }
         });
+
+        // Configure editor readonly depending on editor mode.
+        // Is set after opening the editor each time but the
+        // editor mode may change while the editor is open, making this handler necessary.
+        this.editorModeController?.onModeChange(() => {
+            this.editor?.updateOptions({
+                readOnly: this.editorModeController?.isReadOnly() ?? false,
+            });
+        });
     }
 
     protected onBeforeShow(
@@ -459,6 +472,11 @@ export class OutputPortEditUI extends AbstractUIExtension {
         // Load the current behavior text of the port into the text editor.
         this.editor?.setValue(this.port.behavior);
         this.editor?.layout();
+
+        // Configure editor readonly depending on editor mode
+        this.editor?.updateOptions({
+            readOnly: this.editorModeController?.isReadOnly() ?? false,
+        });
 
         // Validation of loaded behavior text.
         this.validateBehavior();

--- a/src/features/editorMode/command.ts
+++ b/src/features/editorMode/command.ts
@@ -1,0 +1,87 @@
+import { inject } from "inversify";
+import { Command, TYPES, CommandExecutionContext, CommandReturn } from "sprotty";
+import { Action } from "sprotty-protocol";
+import { DfdNodeValidationResult, DfdNodeImpl } from "../dfdElements/nodes";
+import { EditorMode, EditorModeController } from "./editorModeController";
+
+export interface ChangeEditorModeAction extends Action {
+    kind: typeof ChangeEditorModeAction.KIND;
+    newMode: EditorMode;
+}
+export namespace ChangeEditorModeAction {
+    export const KIND = "changeEditorMode";
+
+    export function create(newMode: EditorMode): ChangeEditorModeAction {
+        return {
+            kind: KIND,
+            newMode,
+        };
+    }
+}
+
+export class ChangeEditorModeCommand extends Command {
+    static readonly KIND = ChangeEditorModeAction.KIND;
+
+    private oldMode?: EditorMode;
+    private oldNodeValidationResults: Map<string, DfdNodeValidationResult> = new Map();
+
+    @inject(EditorModeController)
+    private readonly controller?: EditorModeController;
+
+    constructor(@inject(TYPES.Action) private action: ChangeEditorModeAction) {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): CommandReturn {
+        if (!this.controller) throw new Error("Missing injects");
+
+        this.oldMode = this.controller.getCurrentMode();
+        this.controller.setMode(this.action.newMode);
+        this.postModeSwitch(context);
+
+        return context.root;
+    }
+
+    undo(context: CommandExecutionContext): CommandReturn {
+        if (!this.controller) throw new Error("Missing injects");
+
+        if (!this.oldMode) {
+            // This should never happen because execute() is called before undo() is called.
+            throw new Error("No old mode to restore");
+        }
+        this.controller.setMode(this.oldMode);
+        this.undoPostModeSwitch(context);
+
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): CommandReturn {
+        return this.execute(context);
+    }
+
+    private postModeSwitch(context: CommandExecutionContext): void {
+        if (this.oldMode === "validation" && this.action.newMode === "edit") {
+            // Remove validation errors when enabling editing
+
+            this.oldNodeValidationResults.clear();
+            context.root.index.all().forEach((element) => {
+                if (element instanceof DfdNodeImpl && element.validationResult) {
+                    this.oldNodeValidationResults.set(element.id, element.validationResult);
+                    element.validationResult = undefined;
+                }
+            });
+        }
+    }
+
+    private undoPostModeSwitch(context: CommandExecutionContext): void {
+        if (this.oldMode === "validation" && this.action.newMode === "edit") {
+            // Restore validation errors when disabling editing
+            this.oldNodeValidationResults.forEach((validationResult, id) => {
+                const element = context.root.index.getById(id);
+                if (element instanceof DfdNodeImpl) {
+                    element.validationResult = validationResult;
+                }
+            });
+        }
+    }
+}

--- a/src/features/editorMode/command.ts
+++ b/src/features/editorMode/command.ts
@@ -1,7 +1,7 @@
 import { inject } from "inversify";
 import { Command, TYPES, CommandExecutionContext, CommandReturn } from "sprotty";
 import { Action } from "sprotty-protocol";
-import { DfdNodeValidationResult, DfdNodeImpl } from "../dfdElements/nodes";
+import { DfdNodeAnnotation, DfdNodeImpl } from "../dfdElements/nodes";
 import { EditorMode, EditorModeController } from "./editorModeController";
 
 export interface ChangeEditorModeAction extends Action {
@@ -23,7 +23,7 @@ export class ChangeEditorModeCommand extends Command {
     static readonly KIND = ChangeEditorModeAction.KIND;
 
     private oldMode?: EditorMode;
-    private oldNodeValidationResults: Map<string, DfdNodeValidationResult> = new Map();
+    private oldNodeAnnotations: Map<string, DfdNodeAnnotation> = new Map();
 
     @inject(EditorModeController)
     private readonly controller?: EditorModeController;
@@ -60,26 +60,26 @@ export class ChangeEditorModeCommand extends Command {
     }
 
     private postModeSwitch(context: CommandExecutionContext): void {
-        if (this.oldMode === "validation" && this.action.newMode === "edit") {
-            // Remove validation errors when enabling editing
+        if (this.oldMode === "annotated" && this.action.newMode === "edit") {
+            // Remove annotations when enabling editing
 
-            this.oldNodeValidationResults.clear();
+            this.oldNodeAnnotations.clear();
             context.root.index.all().forEach((element) => {
-                if (element instanceof DfdNodeImpl && element.validationResult) {
-                    this.oldNodeValidationResults.set(element.id, element.validationResult);
-                    element.validationResult = undefined;
+                if (element instanceof DfdNodeImpl && element.annotation) {
+                    this.oldNodeAnnotations.set(element.id, element.annotation);
+                    element.annotation = undefined;
                 }
             });
         }
     }
 
     private undoPostModeSwitch(context: CommandExecutionContext): void {
-        if (this.oldMode === "validation" && this.action.newMode === "edit") {
-            // Restore validation errors when disabling editing
-            this.oldNodeValidationResults.forEach((validationResult, id) => {
+        if (this.oldMode === "annotated" && this.action.newMode === "edit") {
+            // Restore annotations when disabling editing
+            this.oldNodeAnnotations.forEach((annotation, id) => {
                 const element = context.root.index.getById(id);
                 if (element instanceof DfdNodeImpl) {
-                    element.validationResult = validationResult;
+                    element.annotation = annotation;
                 }
             });
         }

--- a/src/features/editorMode/di.config.ts
+++ b/src/features/editorMode/di.config.ts
@@ -1,0 +1,16 @@
+import { ContainerModule } from "inversify";
+import { TYPES, configureCommand } from "sprotty";
+import { ChangeEditorModeCommand, EditorModeController } from "./editorModeController";
+import { EditorModeSwitchUi } from "./modeSwitchUi";
+import { EDITOR_TYPES } from "../../utils";
+
+export const editorModeModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+    const context = { bind, unbind, isBound, rebind };
+
+    bind(EditorModeController).toSelf().inSingletonScope();
+    bind(EditorModeSwitchUi).toSelf().inSingletonScope();
+    bind(TYPES.IUIExtension).toService(EditorModeSwitchUi);
+    bind(EDITOR_TYPES.DefaultUIElement).toService(EditorModeSwitchUi);
+
+    configureCommand(context, ChangeEditorModeCommand);
+});

--- a/src/features/editorMode/di.config.ts
+++ b/src/features/editorMode/di.config.ts
@@ -1,8 +1,14 @@
 import { ContainerModule } from "inversify";
-import { TYPES, configureCommand } from "sprotty";
-import { ChangeEditorModeCommand, EditorModeController } from "./editorModeController";
+import { DeleteElementCommand, EditLabelMouseListener, MoveCommand, TYPES, configureCommand } from "sprotty";
+import { EditorModeController } from "./editorModeController";
 import { EditorModeSwitchUi } from "./modeSwitchUi";
 import { EDITOR_TYPES } from "../../utils";
+import {
+    EditorModeAwareDeleteElementCommand,
+    EditorModeAwareEditLabelMouseListener,
+    EditorModeAwareMoveCommand,
+} from "./sprottyHooks";
+import { ChangeEditorModeCommand } from "./command";
 
 export const editorModeModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     const context = { bind, unbind, isBound, rebind };
@@ -13,4 +19,10 @@ export const editorModeModule = new ContainerModule((bind, unbind, isBound, rebi
     bind(EDITOR_TYPES.DefaultUIElement).toService(EditorModeSwitchUi);
 
     configureCommand(context, ChangeEditorModeCommand);
+
+    // Sprotty hooks that hook into the edit label, move and edit module
+    // to intercept model modifications to prevent them when the editor is in a read-only mode.
+    rebind(EditLabelMouseListener).to(EditorModeAwareEditLabelMouseListener).inSingletonScope();
+    rebind(MoveCommand).to(EditorModeAwareMoveCommand).inSingletonScope();
+    rebind(DeleteElementCommand).to(EditorModeAwareDeleteElementCommand).inSingletonScope();
 });

--- a/src/features/editorMode/di.config.ts
+++ b/src/features/editorMode/di.config.ts
@@ -22,7 +22,7 @@ export const editorModeModule = new ContainerModule((bind, unbind, isBound, rebi
 
     // Sprotty hooks that hook into the edit label, move and edit module
     // to intercept model modifications to prevent them when the editor is in a read-only mode.
-    rebind(EditLabelMouseListener).to(EditorModeAwareEditLabelMouseListener).inSingletonScope();
-    rebind(MoveCommand).to(EditorModeAwareMoveCommand).inSingletonScope();
-    rebind(DeleteElementCommand).to(EditorModeAwareDeleteElementCommand).inSingletonScope();
+    rebind(EditLabelMouseListener).to(EditorModeAwareEditLabelMouseListener);
+    rebind(MoveCommand).to(EditorModeAwareMoveCommand);
+    rebind(DeleteElementCommand).to(EditorModeAwareDeleteElementCommand);
 });

--- a/src/features/editorMode/editorModeController.ts
+++ b/src/features/editorMode/editorModeController.ts
@@ -1,6 +1,6 @@
 import { injectable } from "inversify";
 
-export type EditorMode = "edit" | "validation" | "readonly";
+export type EditorMode = "edit" | "annotated" | "readonly";
 
 /**
  * Holds the current editor mode in a central place.

--- a/src/features/editorMode/editorModeController.ts
+++ b/src/features/editorMode/editorModeController.ts
@@ -1,0 +1,100 @@
+import { inject, injectable } from "inversify";
+import { Command, CommandExecutionContext, CommandReturn, TYPES } from "sprotty";
+import { Action } from "sprotty-protocol";
+import { DfdNodeImpl } from "../dfdElements/nodes";
+
+export type EditorMode = "edit" | "validation" | "readonly";
+
+/**
+ * Holds the current editor mode in a central place.
+ * Used to get the current mode in places where it is used.
+ *
+ * Changes to the mode should be done using the ChangeEditorModeCommand
+ * and not directly on this class when done interactively
+ * for undo/redo support and actions that are done to the model
+ * when the mode changes.
+ */
+@injectable()
+export class EditorModeController {
+    private mode: EditorMode = "edit";
+    private modeChangeCallbacks: ((mode: EditorMode) => void)[] = [];
+
+    getCurrentMode(): EditorMode {
+        return this.mode;
+    }
+
+    setMode(mode: EditorMode) {
+        this.mode = mode;
+
+        this.modeChangeCallbacks.forEach((callback) => callback(mode));
+    }
+
+    onModeChange(callback: (mode: EditorMode) => void) {
+        this.modeChangeCallbacks.push(callback);
+    }
+}
+
+export interface ChangeEditorModeAction extends Action {
+    kind: typeof ChangeEditorModeAction.KIND;
+    newMode: EditorMode;
+}
+export namespace ChangeEditorModeAction {
+    export const KIND = "changeEditorMode";
+
+    export function create(newMode: EditorMode): ChangeEditorModeAction {
+        return {
+            kind: KIND,
+            newMode,
+        };
+    }
+}
+
+export class ChangeEditorModeCommand extends Command {
+    static readonly KIND = ChangeEditorModeAction.KIND;
+
+    private oldMode?: EditorMode;
+
+    @inject(EditorModeController)
+    private readonly controller?: EditorModeController;
+
+    constructor(@inject(TYPES.Action) private action: ChangeEditorModeAction) {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): CommandReturn {
+        if (!this.controller) throw new Error("Missing injects");
+
+        this.oldMode = this.controller.getCurrentMode();
+        this.controller.setMode(this.action.newMode);
+        this.postModeSwitch(context);
+
+        return context.root;
+    }
+
+    private postModeSwitch(context: CommandExecutionContext): void {
+        if (this.oldMode === "validation" && this.action.newMode === "edit") {
+            // Remove validation errors when enabling editing
+            context.root.index.all().forEach((element) => {
+                if (element instanceof DfdNodeImpl) {
+                    element.validationResult = undefined;
+                }
+            });
+        }
+    }
+
+    undo(context: CommandExecutionContext): CommandReturn {
+        if (!this.controller) throw new Error("Missing injects");
+
+        if (!this.oldMode) {
+            // This should never happen because execute() is called before undo() is called.
+            throw new Error("No old mode to restore");
+        }
+        this.controller.setMode(this.oldMode);
+
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): CommandReturn {
+        return this.execute(context);
+    }
+}

--- a/src/features/editorMode/editorModeController.ts
+++ b/src/features/editorMode/editorModeController.ts
@@ -1,7 +1,4 @@
-import { inject, injectable } from "inversify";
-import { Command, CommandExecutionContext, CommandReturn, TYPES } from "sprotty";
-import { Action } from "sprotty-protocol";
-import { DfdNodeImpl, DfdNodeValidationResult } from "../dfdElements/nodes";
+import { injectable } from "inversify";
 
 export type EditorMode = "edit" | "validation" | "readonly";
 
@@ -36,86 +33,8 @@ export class EditorModeController {
     onModeChange(callback: (mode: EditorMode) => void) {
         this.modeChangeCallbacks.push(callback);
     }
-}
 
-export interface ChangeEditorModeAction extends Action {
-    kind: typeof ChangeEditorModeAction.KIND;
-    newMode: EditorMode;
-}
-export namespace ChangeEditorModeAction {
-    export const KIND = "changeEditorMode";
-
-    export function create(newMode: EditorMode): ChangeEditorModeAction {
-        return {
-            kind: KIND,
-            newMode,
-        };
-    }
-}
-
-export class ChangeEditorModeCommand extends Command {
-    static readonly KIND = ChangeEditorModeAction.KIND;
-
-    private oldMode?: EditorMode;
-    private oldNodeValidationResults: Map<string, DfdNodeValidationResult> = new Map();
-
-    @inject(EditorModeController)
-    private readonly controller?: EditorModeController;
-
-    constructor(@inject(TYPES.Action) private action: ChangeEditorModeAction) {
-        super();
-    }
-
-    execute(context: CommandExecutionContext): CommandReturn {
-        if (!this.controller) throw new Error("Missing injects");
-
-        this.oldMode = this.controller.getCurrentMode();
-        this.controller.setMode(this.action.newMode);
-        this.postModeSwitch(context);
-
-        return context.root;
-    }
-
-    undo(context: CommandExecutionContext): CommandReturn {
-        if (!this.controller) throw new Error("Missing injects");
-
-        if (!this.oldMode) {
-            // This should never happen because execute() is called before undo() is called.
-            throw new Error("No old mode to restore");
-        }
-        this.controller.setMode(this.oldMode);
-        this.undoPostModeSwitch(context);
-
-        return context.root;
-    }
-
-    redo(context: CommandExecutionContext): CommandReturn {
-        return this.execute(context);
-    }
-
-    private postModeSwitch(context: CommandExecutionContext): void {
-        if (this.oldMode === "validation" && this.action.newMode === "edit") {
-            // Remove validation errors when enabling editing
-
-            this.oldNodeValidationResults.clear();
-            context.root.index.all().forEach((element) => {
-                if (element instanceof DfdNodeImpl && element.validationResult) {
-                    this.oldNodeValidationResults.set(element.id, element.validationResult);
-                    element.validationResult = undefined;
-                }
-            });
-        }
-    }
-
-    private undoPostModeSwitch(context: CommandExecutionContext): void {
-        if (this.oldMode === "validation" && this.action.newMode === "edit") {
-            // Restore validation errors when disabling editing
-            this.oldNodeValidationResults.forEach((validationResult, id) => {
-                const element = context.root.index.getById(id);
-                if (element instanceof DfdNodeImpl) {
-                    element.validationResult = validationResult;
-                }
-            });
-        }
+    isReadOnly(): boolean {
+        return this.mode !== "edit";
     }
 }

--- a/src/features/editorMode/modeSwitchUi.css
+++ b/src/features/editorMode/modeSwitchUi.css
@@ -1,0 +1,10 @@
+.editor-mode-switcher {
+    /* Position the switcher in the top left corner */
+    top: 40px;
+    padding: 8px;
+    left: 40px;
+
+    /* Make text non-selectable */
+    -webkit-user-select: none; /* Safari only supports user select using the -webkit prefix */
+    user-select: none;
+}

--- a/src/features/editorMode/modeSwitchUi.ts
+++ b/src/features/editorMode/modeSwitchUi.ts
@@ -8,7 +8,7 @@ import "./modeSwitchUi.css";
 /**
  * UI that shows the current editor mode (unless it is edit mode)
  * with details about the mode.
- * For validation mode the user can also choose to enable editing
+ * For annotated mode the user can also choose to enable editing
  * and switch the editor to edit mode.
  */
 @injectable()
@@ -47,19 +47,19 @@ export class EditorModeSwitchUi extends AbstractUIExtension {
                 this.containerElement.style.visibility = "visible";
                 this.renderReadonlyMode();
                 break;
-            case "validation":
+            case "annotated":
                 this.containerElement.style.visibility = "visible";
-                this.renderValidationMode();
+                this.renderAnnotatedMode();
                 break;
             default:
                 throw new Error(`Unknown editor mode: ${mode}`);
         }
     }
 
-    private renderValidationMode(): void {
+    private renderAnnotatedMode(): void {
         this.containerElement.innerHTML = `
-            Currently viewing validation errors from the analysis.</br>
-            Enabling editing will remove the validation errors.</br>
+            Currently viewing model annotations.</br>
+            Enabling editing will remove the annotations.</br>
             <button id="enableEditingButton">Enable editing</button>
         `;
         const enableEditingButton = this.containerElement.querySelector("#enableEditingButton");
@@ -70,8 +70,7 @@ export class EditorModeSwitchUi extends AbstractUIExtension {
 
     private renderReadonlyMode(): void {
         this.containerElement.innerHTML = `
-            This diagram was generated from a palladio model.</br>
-            Model is readonly.
+            This diagram was generated and is readonly.
         `;
     }
 }

--- a/src/features/editorMode/modeSwitchUi.ts
+++ b/src/features/editorMode/modeSwitchUi.ts
@@ -33,8 +33,7 @@ export class EditorModeSwitchUi extends AbstractUIExtension {
     protected initializeContents(containerElement: HTMLElement): void {
         containerElement.classList.add("ui-float");
         this.editorModeController.onModeChange((mode) => this.reRender(mode));
-        // Only for testing, TODO: remove when mode is loaded from the model
-        this.editorModeController.setMode("validation");
+        this.reRender(this.editorModeController.getCurrentMode());
     }
 
     private reRender(mode: EditorMode): void {

--- a/src/features/editorMode/modeSwitchUi.ts
+++ b/src/features/editorMode/modeSwitchUi.ts
@@ -1,6 +1,7 @@
 import { AbstractUIExtension, ActionDispatcher, TYPES } from "sprotty";
-import { ChangeEditorModeAction, EditorMode, EditorModeController } from "./editorModeController";
+import { EditorMode, EditorModeController } from "./editorModeController";
 import { inject, injectable } from "inversify";
+import { ChangeEditorModeAction } from "./command";
 
 import "./modeSwitchUi.css";
 

--- a/src/features/editorMode/modeSwitchUi.ts
+++ b/src/features/editorMode/modeSwitchUi.ts
@@ -33,6 +33,7 @@ export class EditorModeSwitchUi extends AbstractUIExtension {
 
     protected initializeContents(containerElement: HTMLElement): void {
         containerElement.classList.add("ui-float");
+        containerElement.style.visibility = "hidden";
         this.editorModeController.onModeChange((mode) => this.reRender(mode));
         this.reRender(this.editorModeController.getCurrentMode());
     }

--- a/src/features/editorMode/modeSwitchUi.ts
+++ b/src/features/editorMode/modeSwitchUi.ts
@@ -58,7 +58,7 @@ export class EditorModeSwitchUi extends AbstractUIExtension {
 
     private renderValidationMode(): void {
         this.containerElement.innerHTML = `
-            Currently validation errors from the analysis.</br>
+            Currently viewing validation errors from the analysis.</br>
             Enabling editing will remove the validation errors.</br>
             <button id="enableEditingButton">Enable editing</button>
         `;

--- a/src/features/editorMode/modeSwitchUi.ts
+++ b/src/features/editorMode/modeSwitchUi.ts
@@ -1,0 +1,77 @@
+import { AbstractUIExtension, ActionDispatcher, TYPES } from "sprotty";
+import { ChangeEditorModeAction, EditorMode, EditorModeController } from "./editorModeController";
+import { inject, injectable } from "inversify";
+
+import "./modeSwitchUi.css";
+
+/**
+ * UI that shows the current editor mode (unless it is edit mode)
+ * with details about the mode.
+ * For validation mode the user can also choose to enable editing
+ * and switch the editor to edit mode.
+ */
+@injectable()
+export class EditorModeSwitchUi extends AbstractUIExtension {
+    static readonly ID = "editor-mode-switcher";
+
+    constructor(
+        @inject(EditorModeController)
+        private readonly editorModeController: EditorModeController,
+        @inject(TYPES.IActionDispatcher)
+        private readonly actionDispatcher: ActionDispatcher,
+    ) {
+        super();
+    }
+
+    id(): string {
+        return EditorModeSwitchUi.ID;
+    }
+    containerClass(): string {
+        return this.id();
+    }
+
+    protected initializeContents(containerElement: HTMLElement): void {
+        containerElement.classList.add("ui-float");
+        this.editorModeController.onModeChange((mode) => this.reRender(mode));
+        // Only for testing, TODO: remove when mode is loaded from the model
+        this.editorModeController.setMode("validation");
+    }
+
+    private reRender(mode: EditorMode): void {
+        this.containerElement.innerHTML = "";
+        switch (mode) {
+            case "edit":
+                this.containerElement.style.visibility = "hidden";
+                break;
+            case "readonly":
+                this.containerElement.style.visibility = "visible";
+                this.renderReadonlyMode();
+                break;
+            case "validation":
+                this.containerElement.style.visibility = "visible";
+                this.renderValidationMode();
+                break;
+            default:
+                throw new Error(`Unknown editor mode: ${mode}`);
+        }
+    }
+
+    private renderValidationMode(): void {
+        this.containerElement.innerHTML = `
+            Currently validation errors from the analysis.</br>
+            Enabling editing will remove the validation errors.</br>
+            <button id="enableEditingButton">Enable editing</button>
+        `;
+        const enableEditingButton = this.containerElement.querySelector("#enableEditingButton");
+        enableEditingButton?.addEventListener("click", () => {
+            this.actionDispatcher.dispatch(ChangeEditorModeAction.create("edit"));
+        });
+    }
+
+    private renderReadonlyMode(): void {
+        this.containerElement.innerHTML = `
+            This diagram was generated from a palladio model.</br>
+            Model is readonly.
+        `;
+    }
+}

--- a/src/features/editorMode/sprottyHooks.ts
+++ b/src/features/editorMode/sprottyHooks.ts
@@ -1,0 +1,90 @@
+import { inject, injectable } from "inversify";
+import {
+    CommandExecutionContext,
+    CommandReturn,
+    DeleteElementCommand,
+    EditLabelMouseListener,
+    MoveCommand,
+    SModelElementImpl,
+    SModelRootImpl,
+} from "sprotty";
+import { EditorModeController } from "./editorModeController";
+import { Action } from "sprotty-protocol";
+
+@injectable()
+export class EditorModeAwareEditLabelMouseListener extends EditLabelMouseListener {
+    constructor(
+        @inject(EditorModeController)
+        private readonly editorModeController: EditorModeController,
+    ) {
+        super();
+    }
+
+    doubleClick(target: SModelElementImpl, event: MouseEvent): (Action | Promise<Action>)[] {
+        if (this.editorModeController.isReadOnly()) {
+            return [];
+        }
+
+        return super.doubleClick(target, event);
+    }
+}
+
+@injectable()
+export class EditorModeAwareMoveCommand extends MoveCommand {
+    @inject(EditorModeController)
+    private readonly editorModeController?: EditorModeController;
+
+    execute(context: CommandExecutionContext): CommandReturn {
+        if (this.editorModeController?.isReadOnly()) {
+            return context.root;
+        }
+
+        return super.execute(context);
+    }
+
+    undo(context: CommandExecutionContext): Promise<SModelRootImpl> {
+        if (this.editorModeController?.isReadOnly()) {
+            return Promise.resolve(context.root);
+        }
+
+        return super.undo(context);
+    }
+
+    redo(context: CommandExecutionContext): Promise<SModelRootImpl> {
+        if (this.editorModeController?.isReadOnly()) {
+            return Promise.resolve(context.root);
+        }
+
+        return super.redo(context);
+    }
+}
+
+@injectable()
+export class EditorModeAwareDeleteElementCommand extends DeleteElementCommand {
+    @inject(EditorModeController)
+    private readonly editorModeController?: EditorModeController;
+
+    execute(context: CommandExecutionContext): CommandReturn {
+        if (this.editorModeController?.isReadOnly()) {
+            return context.root;
+        }
+
+        return super.execute(context);
+    }
+
+    undo(context: CommandExecutionContext): CommandReturn {
+        if (this.editorModeController?.isReadOnly()) {
+            return context.root;
+        }
+
+        return super.undo(context);
+    }
+
+    redo(context: CommandExecutionContext): CommandReturn {
+        if (this.editorModeController?.isReadOnly()) {
+            return context.root;
+        }
+
+        return super.redo(context);
+    }
+}

--- a/src/features/labels/commands.ts
+++ b/src/features/labels/commands.ts
@@ -9,10 +9,11 @@ import {
     SParentElementImpl,
     TYPES,
 } from "sprotty";
-import { injectable, inject } from "inversify";
+import { injectable, inject, optional } from "inversify";
 import { ContainsDfdLabels, containsDfdLabels } from "./elementFeature";
 import { LabelAssignment, LabelTypeRegistry } from "./labelTypeRegistry";
 import { snapPortsOfNode } from "../dfdElements/portSnapper";
+import { EditorModeController } from "../editorMode/editorModeController";
 
 export interface AddLabelAssignmentAction extends Action {
     kind: typeof AddLabelAssignmentAction.TYPE;
@@ -38,6 +39,10 @@ export class AddLabelAssignmentCommand extends Command {
     public static readonly KIND = AddLabelAssignmentAction.TYPE;
     private hasBeenAdded = false;
 
+    @inject(EditorModeController)
+    @optional()
+    private readonly editorModeController?: EditorModeController;
+
     constructor(
         @inject(TYPES.Action) private action: AddLabelAssignmentAction,
         @inject(TYPES.ISnapper) private snapper: ISnapper,
@@ -46,6 +51,10 @@ export class AddLabelAssignmentCommand extends Command {
     }
 
     execute(context: CommandExecutionContext): CommandReturn {
+        if (this.editorModeController?.isReadOnly()) {
+            return context.root;
+        }
+
         // Check whether the element already has a label with the same type and value assigned
         this.hasBeenAdded =
             this.action.element.labels.find((as) => {
@@ -64,6 +73,10 @@ export class AddLabelAssignmentCommand extends Command {
     }
 
     undo(context: CommandExecutionContext): CommandReturn {
+        if (this.editorModeController?.isReadOnly()) {
+            return context.root;
+        }
+
         const labels = this.action.element.labels;
         const idx = labels.indexOf(this.action.labelAssignment);
         if (idx >= 0 && this.hasBeenAdded) {
@@ -102,6 +115,10 @@ export namespace DeleteLabelAssignmentAction {
 export class DeleteLabelAssignmentCommand extends Command {
     public static readonly KIND = DeleteLabelAssignmentAction.TYPE;
 
+    @inject(EditorModeController)
+    @optional()
+    private readonly editorModeController?: EditorModeController;
+
     constructor(
         @inject(TYPES.Action) private action: DeleteLabelAssignmentAction,
         @inject(TYPES.ISnapper) private snapper: ISnapper,
@@ -110,6 +127,10 @@ export class DeleteLabelAssignmentCommand extends Command {
     }
 
     execute(context: CommandExecutionContext): CommandReturn {
+        if (this.editorModeController?.isReadOnly()) {
+            return context.root;
+        }
+
         const labels = this.action.element.labels;
 
         const idx = labels.indexOf(this.action.labelAssignment);
@@ -122,6 +143,10 @@ export class DeleteLabelAssignmentCommand extends Command {
     }
 
     undo(context: CommandExecutionContext): CommandReturn {
+        if (this.editorModeController?.isReadOnly()) {
+            return context.root;
+        }
+
         const labels = this.action.element.labels;
         labels.push(this.action.labelAssignment);
 
@@ -184,6 +209,10 @@ export namespace DeleteLabelTypeValueAction {
 export class DeleteLabelTypeValueCommand extends Command {
     public static readonly KIND = DeleteLabelTypeValueAction.TYPE;
 
+    @inject(EditorModeController)
+    @optional()
+    private readonly editorModeController?: EditorModeController;
+
     constructor(
         @inject(TYPES.Action) private action: DeleteLabelTypeValueAction,
         @inject(TYPES.ISnapper) private snapper: ISnapper,
@@ -192,6 +221,10 @@ export class DeleteLabelTypeValueCommand extends Command {
     }
 
     execute(context: CommandExecutionContext): CommandReturn {
+        if (this.editorModeController?.isReadOnly()) {
+            return context.root;
+        }
+
         const labelType = this.action.registry.getLabelType(this.action.labelTypeId);
         if (!labelType) {
             return context.root;
@@ -246,6 +279,10 @@ export namespace DeleteLabelTypeAction {
 export class DeleteLabelTypeCommand extends Command {
     public static readonly KIND = DeleteLabelTypeAction.TYPE;
 
+    @inject(EditorModeController)
+    @optional()
+    private readonly editorModeController?: EditorModeController;
+
     constructor(
         @inject(TYPES.Action) private action: DeleteLabelTypeAction,
         @inject(TYPES.ISnapper) private snapper: ISnapper,
@@ -254,6 +291,10 @@ export class DeleteLabelTypeCommand extends Command {
     }
 
     execute(context: CommandExecutionContext): CommandReturn {
+        if (this.editorModeController?.isReadOnly()) {
+            return context.root;
+        }
+
         const labelType = this.action.registry.getLabelType(this.action.labelTypeId);
         if (!labelType) {
             return context.root;

--- a/src/features/labels/labelTypeEditor.tsx
+++ b/src/features/labels/labelTypeEditor.tsx
@@ -1,4 +1,4 @@
-import { injectable, inject } from "inversify";
+import { injectable, inject, optional } from "inversify";
 import { calculateTextSize, generateRandomSprottyId } from "../../utils";
 import {
     AbstractUIExtension,
@@ -17,6 +17,7 @@ import { Action } from "sprotty-protocol";
 import { snapPortsOfNode } from "../dfdElements/portSnapper";
 import { DfdNodeImpl } from "../dfdElements/nodes";
 import { matchesKeystroke } from "sprotty/lib/utils/keyboard";
+import { EditorModeController } from "../editorMode/editorModeController";
 
 import "../../common/commonStyling.css";
 import "./labelTypeEditor.css";
@@ -30,6 +31,9 @@ export class LabelTypeEditorUI extends AbstractUIExtension implements KeyListene
         @inject(TYPES.IActionDispatcher) private readonly actionDispatcher: IActionDispatcher,
         @inject(TYPES.ICommandStack) private readonly commandStack: CommandStack,
         @inject(TYPES.ISnapper) private readonly snapper: ISnapper,
+        @inject(EditorModeController)
+        @optional()
+        private readonly editorModeController: EditorModeController,
     ) {
         super();
         labelTypeRegistry.onUpdate(() => this.reRender());
@@ -106,6 +110,10 @@ export class LabelTypeEditorUI extends AbstractUIExtension implements KeyListene
         const addButton = document.createElement("button");
         addButton.innerHTML = '<span class="codicon codicon-add"></span> Label Type';
         addButton.onclick = () => {
+            if (this.editorModeController?.isReadOnly()) {
+                return;
+            }
+
             const labelType: LabelType = {
                 id: generateRandomSprottyId(),
                 name: "",
@@ -139,9 +147,13 @@ export class LabelTypeEditorUI extends AbstractUIExtension implements KeyListene
 
         this.dynamicallySetInputSize(labelTypeNameInput);
 
-        // Disallow spaces in label type names
+        // Disallow spaces in label type names and changes when readonly
         labelTypeNameInput.onbeforeinput = (event) => {
             if (event.data?.includes(" ")) {
+                event.preventDefault();
+            }
+
+            if (this.editorModeController && this.editorModeController.isReadOnly()) {
                 event.preventDefault();
             }
         };
@@ -170,6 +182,10 @@ export class LabelTypeEditorUI extends AbstractUIExtension implements KeyListene
         addButton.classList.add("label-type-value-add");
         addButton.innerHTML = '<span class="codicon codicon-add"></span> Value';
         addButton.onclick = () => {
+            if (this.editorModeController?.isReadOnly()) {
+                return;
+            }
+
             const labelValue: LabelTypeValue = {
                 id: generateRandomSprottyId(),
                 text: "",
@@ -197,9 +213,13 @@ export class LabelTypeEditorUI extends AbstractUIExtension implements KeyListene
         valueInput.placeholder = "Value";
         this.dynamicallySetInputSize(valueInput);
 
-        // Disallow spaces in label type values
+        // Disallow spaces in label type values and changes when readonly
         valueInput.onbeforeinput = (event) => {
             if (event.data?.includes(" ")) {
+                event.preventDefault();
+            }
+
+            if (this.editorModeController && this.editorModeController.isReadOnly()) {
                 event.preventDefault();
             }
         };

--- a/src/features/serialize/defaultDiagram.json
+++ b/src/features/serialize/defaultDiagram.json
@@ -622,5 +622,6 @@
                 }
             ]
         }
-    ]
+    ],
+    "editorMode": "edit"
 }

--- a/src/features/serialize/save.ts
+++ b/src/features/serialize/save.ts
@@ -3,6 +3,7 @@ import { Command, CommandExecutionContext, LocalModelSource, SModelRootImpl, TYP
 import { Action, SModelRoot } from "sprotty-protocol";
 import { LabelType, LabelTypeRegistry } from "../labels/labelTypeRegistry";
 import { DynamicChildrenProcessor } from "../dfdElements/dynamicChildren";
+import { EditorMode, EditorModeController } from "../editorMode/editorModeController";
 
 /**
  * Type that contains all data related to a diagram.
@@ -11,6 +12,7 @@ import { DynamicChildrenProcessor } from "../dfdElements/dynamicChildren";
 export interface SavedDiagram {
     model: SModelRoot;
     labelTypes?: LabelType[];
+    editorMode?: EditorMode;
 }
 
 export interface SaveDiagramAction extends Action {
@@ -38,6 +40,9 @@ export class SaveDiagramCommand extends Command {
     @inject(LabelTypeRegistry)
     @optional()
     private labelTypeRegistry?: LabelTypeRegistry;
+    @inject(EditorModeController)
+    @optional()
+    private editorModeController?: EditorModeController;
 
     constructor(@inject(TYPES.Action) private action: SaveDiagramAction) {
         super();
@@ -54,6 +59,7 @@ export class SaveDiagramCommand extends Command {
         const diagram: SavedDiagram = {
             model: modelCopy,
             labelTypes: this.labelTypeRegistry?.getLabelTypes(),
+            editorMode: this.editorModeController?.getCurrentMode(),
         };
         const diagramJson = JSON.stringify(diagram, undefined, 4);
         const jsonBlob = new Blob([diagramJson], { type: "application/json" });

--- a/src/features/toolPalette/toolPalette.tsx
+++ b/src/features/toolPalette/toolPalette.tsx
@@ -1,5 +1,5 @@
 /** @jsx svg */
-import { injectable, inject, multiInject } from "inversify";
+import { injectable, inject, multiInject, optional } from "inversify";
 import { VNode } from "snabbdom";
 import {
     svg,
@@ -20,6 +20,7 @@ import { EdgeCreationTool } from "./edgeCreationTool";
 import { PortCreationTool } from "./portCreationTool";
 import { AnyCreationTool } from "./creationTool";
 import { EDITOR_TYPES } from "../../utils";
+import { EditorModeController } from "../editorMode/editorModeController";
 
 import "../../common/commonStyling.css";
 import "./toolPalette.css";
@@ -40,6 +41,9 @@ export class ToolPaletteUI extends AbstractUIExtension implements IActionHandler
         @inject(EdgeCreationTool) protected readonly edgeCreationTool: EdgeCreationTool,
         @inject(PortCreationTool) protected readonly portCreationTool: PortCreationTool,
         @multiInject(EDITOR_TYPES.CreationTool) protected readonly allTools: AnyCreationTool[],
+        @inject(EditorModeController)
+        @optional()
+        protected readonly editorModeController: EditorModeController,
     ) {
         super();
     }
@@ -179,7 +183,7 @@ export class ToolPaletteUI extends AbstractUIExtension implements IActionHandler
         toolElement.classList.add("tool");
 
         toolElement.addEventListener("click", () => {
-            if (toolElement.classList.contains("active")) {
+            if (toolElement.classList.contains("active") || this.editorModeController?.isReadOnly()) {
                 tool.disable();
                 toolElement.classList.remove("active");
             } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { LoadDefaultDiagramAction } from "./features/serialize/loadDefaultDiagra
 import { dfdElementsModule } from "./features/dfdElements/di.config";
 import { copyPasteModule } from "./features/copyPaste/di.config";
 import { EDITOR_TYPES } from "./utils";
+import { editorModeModule } from "./features/editorMode/di.config";
 
 import "sprotty/css/sprotty.css";
 import "sprotty/css/edit-label.css";
@@ -47,6 +48,7 @@ container.load(
     dfdElementsModule,
     serializeModule,
     dfdLabelModule,
+    editorModeModule,
     toolPaletteModule,
     copyPasteModule,
 );

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,7 +1,7 @@
 :root {
     --color-foreground: #000;
     --color-background: #fff;
-    --color-primary: #eee;
+    --color-primary: #dfdfdf;
     --color-error: #f00;
     --color-valid: #00b600;
     --color-tool-palette-hover: #ccc;


### PR DESCRIPTION
This PR adds two things interacting with each other:
- Optional Node Annotations
- Editor Modes

## Node Annotations
Adds optional annotation to DFD nodes.
These include a mandatory message, optional color and optional (FontAwesome Free) icon.
For nodes that have an annotation a popup will open when hovering over them.
This popup shows the annotated message. This could be an analysis warning/error or pretty much anything.
When the icon is set the FontAwesome icon with the provided id will be prepended to the annotation message.
When the color of the annotation is set, the node will have a border in that color and a background with a dimmed version of that color.

The only way to add an annotation to a node is to set the `annotation` object inside the JSON object for the node.
These can be included when generating the diagram from other sources. There is no way to add annotations using the editor itself, that is (currently) not an intended use case.
Here's an example annotation:
````json5
{
    // rest of the node
    "annotation": {
        "message": "This node has a invalid output port/pin with an erroneous behavior definition",
        "icon": "bug",
        "color": "#ff0000"
    }
}
````

- `message` must always be set when `annotation` is set to an object.
- `icon` can be the id of any FontAwesome Free icon. Note that always the solid version of the icon is used, all other versions are only available with FontAwesome Pro at the point of writing, so you couldn't use the other versions anyway.
- `color` can be undefined/not included or any color. Theoretically the current implementation would allow any valid CSS color definition, like `red` or `rgba(...)` but for stability it is recommended to only use hex definitions of RGB colors (like shown above). Only those are guaranteed to be supported in the future. When no color is provided the node will have the default color like not annotated nodes, meaning white/black depending on white/dark mode.


## Editor Modes

Another thing this PR adds are three editor modes:
- `edit`: the functionality like before this PR. You can view the diagram, change labels, move elements, create new nodes/ports/edges, etc.
- `annotated`: This is the intended mode for viewing node annotations that are introduced above. With this mode the model is in a readonly state. However there is a button in the UI that allows to change the diagram to `edit` mode. This will delete all annotations and make the model editable. Intended for viewing errors/validation messages from the DFD analysis. After viewing the annotations the user can delete them and perform the necessary fixes in the diagram.
- `readonly`: Similar to `annotated`. The model is in a readonly state, however there is no UI button to change the editor to the `edit` mode. Intended for generated diagrams from other sources.

When the model is in a readonly state the user cannot create new elements, delete elements, change the DFD or node labels, etc. However the user can still look around the diagram, view DFD output port behaviors, view node annotations by hovering on the respective nodes, etc.

The editor mode is saved inside the model JSON as an extra top level field.
E.g.
```json5
{
    "model": {/* ... */},
    "labelTypes": [/* ... */],
    "editorMode": "annotated"
}
```

When there is no editor mode set in the JSON representation of the model, the `edit` mode is used for backwards compability.