### PR TITLE
Force line endings of output port behavior editor to always be LF

### DIFF
--- a/src/features/dfdElements/outputPortEditUi.ts
+++ b/src/features/dfdElements/outputPortEditUi.ts
@@ -556,6 +556,7 @@ export class OutputPortEditUI extends AbstractUIExtension {
 
         // Load the current behavior text of the port into the text editor.
         this.editor?.setValue(this.port.behavior);
+        this.editor?.getModel()?.setEOL(monaco.editor.EndOfLineSequence.LF);
         this.resizeEditor();
 
         // Configure editor readonly depending on editor mode


### PR DESCRIPTION
Fixes #43 

As explained in the linked issue the validation failures are caused by end of lines sometimes being marked using `\r\n` instead of just `\n` that the validation logic expects. monaco auto decides whether it should use `\r\n` or `\n` based on some criteria that I don't fully instead by default. On linux it is always `\n`, on windows it sometimes is `\n` and on other systems its `\r\n`.
This PR forces monaco to just use `\n` as a end-of-line marker to ensure only text is produced without `\r` as expected by the validation.

(You have to merge this PR yourself. I don't have write access to this repository anymore. I still have write access to the GDPR editor so I don't know whether this is intentional)