### PR TITLE
Fix deletion of temporary empty-nodes

### DIFF
--- a/src/features/serialize/defaultDiagram.json
+++ b/src/features/serialize/defaultDiagram.json
@@ -165,24 +165,6 @@
             },
             {
                 "position": {
-                    "x": 420.76127480457006,
-                    "y": 89.13650030066145
-                },
-                "size": {
-                    "width": -1,
-                    "height": -1
-                },
-                "strokeWidth": 0,
-                "selected": false,
-                "hoverFeedback": false,
-                "opacity": 1,
-                "features": {},
-                "id": "xccftn",
-                "type": "empty-node",
-                "children": []
-            },
-            {
-                "position": {
                     "x": 249,
                     "y": 67
                 },

--- a/src/features/toolPalette/edgeCreationTool.ts
+++ b/src/features/toolPalette/edgeCreationTool.ts
@@ -91,8 +91,6 @@ export class EdgeCreationTool extends CreationTool<SEdge, SEdgeImpl> {
                 // Add empty node to the graph and as a edge target
                 root.add(this.edgeTargetElement);
                 this.element.targetId = this.edgeTargetElement.id;
-
-                console.log(root);
             }
         }
         return [];

--- a/src/features/toolPalette/edgeCreationTool.ts
+++ b/src/features/toolPalette/edgeCreationTool.ts
@@ -36,7 +36,7 @@ export class EdgeCreationTool extends CreationTool<SEdge, SEdgeImpl> {
         if (this.edgeTargetElement) {
             // Pseudo edge target element must always be removed
             // regardless of whether the edge creation was successful or cancelled
-            this.element?.root.remove(this.edgeTargetElement);
+            this.edgeTargetElement.parent?.remove(this.edgeTargetElement);
             this.edgeTargetElement = undefined;
         }
 
@@ -91,6 +91,8 @@ export class EdgeCreationTool extends CreationTool<SEdge, SEdgeImpl> {
                 // Add empty node to the graph and as a edge target
                 root.add(this.edgeTargetElement);
                 this.element.targetId = this.edgeTargetElement.id;
+
+                console.log(root);
             }
         }
         return [];


### PR DESCRIPTION
This PR addresses a bug where temporary "empty-node" are created upon edge created but never removed, resulting in them persisting into the JSON