### PR TITLE
Assignment Definition Changes

### DIFF
--- a/src/features/dfdElements/outputPortBehaviorValidation.ts
+++ b/src/features/dfdElements/outputPortBehaviorValidation.ts
@@ -28,9 +28,6 @@ export class PortBehaviorValidator {
     // Has the label type and label value that should be set as capturing groups.
     private static readonly TERM_REGEX =
         /^(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z][A-Za-z0-9_]*\.[A-Za-z][A-Za-z0-9_]*))+$/;
-    // Regex that is used to extract all inputs, their label types and label values from a set statement.
-    // Each input is a match with the input name, label type and label value as capturing groups.
-    private static readonly SET_REGEX_EXPRESSION_INPUTS = /([A-Za-z][A-Za-z0-9_\|]*)\.([A-Za-z][A-Za-z0-9_\|]*)/g;
     // Regex matching alphanumeric characters.
     public static readonly REGEX_ALPHANUMERIC = /[A-Za-z0-9_\|]+/;
 

--- a/src/features/dfdElements/outputPortBehaviorValidation.ts
+++ b/src/features/dfdElements/outputPortBehaviorValidation.ts
@@ -32,7 +32,7 @@ export class PortBehaviorValidator {
 
     // Regex that validates a term
     // Has the label type and label value that should be set as capturing groups.
-    private static readonly TERM_REGEX = /^(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z0-9_]*\.[A-Za-z0-9_]*))+$/;
+    private static readonly TERM_REGEX = /^(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z0-9_]+\.[A-Za-z0-9_]+))+$/;
 
     private static readonly LABEL_REGEX = /([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)/g;
 

--- a/src/features/dfdElements/outputPortBehaviorValidation.ts
+++ b/src/features/dfdElements/outputPortBehaviorValidation.ts
@@ -23,7 +23,7 @@ export class PortBehaviorValidator {
     // Regex that validates assignments
     // Matches "Assignment({input_Pins};Term;{out_Label})"
     private static readonly ASSIGNMENT_REGEX =
-        /^Assignment\(\{(([A-Za-z0-9_\|]+(,\s*[A-Za-z0-9_\|]+)*)?)\};(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z0-9_]*\.[A-Za-z0-9_]*))+;\{(((([A-Za-z0-9_\|]*)\.[A-Za-z0-9_\|]*)+(,\s*([A-Za-z0-9_\|]*\.[A-Za-z0-9_\|]*))*)?)\}\)+$/;
+        /^Assignment\(\{(([A-Za-z0-9_\|]+(,\s*[A-Za-z0-9_\|]+)*)?)\};(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z0-9_]*\.[A-Za-z0-9_]*))+;\{(((([A-Za-z0-9_]*)\.[A-Za-z0-9_]*)+(,\s*([A-Za-z0-9_]*\.[A-Za-z0-9_]*))*)?)\}\)+$/;
 
     // Regex that validates forwarding
     // Matches "Forwarding({input_pins})"

--- a/src/features/dfdElements/outputPortBehaviorValidation.ts
+++ b/src/features/dfdElements/outputPortBehaviorValidation.ts
@@ -23,16 +23,15 @@ export class PortBehaviorValidator {
     // Regex that validates assignments
     // Matches "Assignment({input_Pins};Term;{out_Label})"
     private static readonly ASSIGNMENT_REGEX =
-        /^Assignment\(\{(([A-Za-z0-9_\|]+(,\s*[A-Za-z0-9_\|]+)*)?)\};(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z][A-Za-z0-9_]*\.[A-Za-z][A-Za-z0-9_]*))+;\{(((([A-Za-z][A-Za-z0-9_\|]*)\.([A-Za-z][A-Za-z0-9_\|]*))+(,\s*(([A-Za-z][A-Za-z0-9_\|]*)\.([A-Za-z][A-Za-z0-9_\|]*)))*)?)\}\)+$/;
+        /^Assignment\(\{(([A-Za-z0-9_\|]+(,\s*[A-Za-z0-9_\|]+)*)?)\};(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z0-9_]*\.[A-Za-z0-9_]*))+;\{(((([A-Za-z0-9_\|]*)\.[A-Za-z0-9_\|]*)+(,\s*([A-Za-z0-9_\|]*\.[A-Za-z0-9_\|]*))*)?)\}\)+$/;
 
     // Regex that validates forwarding
     // Matches "Forwarding({input_pins})"
     private static readonly FORWARDING_REGEX = /^Forwarding\(\{[A-Za-z0-9_\|]+(,\s*[A-Za-z0-9_\|]+)*\}\)$/;
 
     // Regex that validates a term
-    // Matches Constants, Operants and Label References
-    private static readonly TERM_REGEX =
-        /^(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z][A-Za-z0-9_]*\.[A-Za-z][A-Za-z0-9_]*))+$/;
+    // Has the label type and label value that should be set as capturing groups.
+    private static readonly TERM_REGEX = /^(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z0-9_]*\.[A-Za-z0-9_]*))+$/;
 
     // Regex matching alphanumeric characters.
     public static readonly REGEX_ALPHANUMERIC = /[A-Za-z0-9_\|]+/;

--- a/src/features/dfdElements/outputPortBehaviorValidation.ts
+++ b/src/features/dfdElements/outputPortBehaviorValidation.ts
@@ -32,7 +32,8 @@ export class PortBehaviorValidator {
 
     // Regex that validates a term
     // Has the label type and label value that should be set as capturing groups.
-    private static readonly TERM_REGEX = /^(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z0-9_]+\.[A-Za-z0-9_]+))+$/;
+    private static readonly TERM_REGEX =
+        /^(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z0-9_]+\.[A-Za-z0-9_]+(?![A-Za-z0-9_]*\.[A-Za-z0-9_]*)))+$/g;
 
     private static readonly LABEL_REGEX = /([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)/g;
 
@@ -335,6 +336,15 @@ export class PortBehaviorValidator {
                     idx = line.indexOf(inputLabelValue, idx + 1);
                 }
             }
+
+            console.log(inputMatch);
+
+            if (inputMatch[3] !== undefined) {
+                inputAccessErrors.push({
+                    line: lineNumber,
+                    message: `invalid label definition`,
+                });
+            }
         }
 
         const node = port.parent;
@@ -450,6 +460,13 @@ export class PortBehaviorValidator {
                         idx = line.indexOf(inputLabelValue, idx + 1);
                     }
                 }
+            }
+
+            if (typeValuePair.split(".")[2] !== undefined) {
+                inputAccessErrors.push({
+                    line: lineNumber,
+                    message: `invalid label definition`,
+                });
             }
         }
 

--- a/src/features/dfdElements/outputPortBehaviorValidation.ts
+++ b/src/features/dfdElements/outputPortBehaviorValidation.ts
@@ -20,14 +20,20 @@ interface PortBehaviorValidationError {
  */
 @injectable()
 export class PortBehaviorValidator {
+    // Regex that validates assignments
+    // Matches "Assignment({input_Pins};Term;{out_Label})"
     private static readonly ASSIGNMENT_REGEX =
         /^Assignment\(\{(([A-Za-z0-9_\|]+(,\s*[A-Za-z0-9_\|]+)*)?)\};(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z][A-Za-z0-9_]*\.[A-Za-z][A-Za-z0-9_]*))+;\{(((([A-Za-z][A-Za-z0-9_\|]*)\.([A-Za-z][A-Za-z0-9_\|]*))+(,\s*(([A-Za-z][A-Za-z0-9_\|]*)\.([A-Za-z][A-Za-z0-9_\|]*)))*)?)\}\)+$/;
+
+    // Regex that validates forwarding
+    // Matches "Forwarding({input_pins})"
     private static readonly FORWARDING_REGEX = /^Forwarding\(\{[A-Za-z0-9_\|]+(,\s*[A-Za-z0-9_\|]+)*\}\)$/;
 
-    // Regex that validates a set statement.
-    // Has the label type and label value that should be set as capturing groups.
+    // Regex that validates a term
+    // Matches Constants, Operants and Label References
     private static readonly TERM_REGEX =
         /^(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z][A-Za-z0-9_]*\.[A-Za-z][A-Za-z0-9_]*))+$/;
+
     // Regex matching alphanumeric characters.
     public static readonly REGEX_ALPHANUMERIC = /[A-Za-z0-9_\|]+/;
 

--- a/src/features/dfdElements/outputPortBehaviorValidation.ts
+++ b/src/features/dfdElements/outputPortBehaviorValidation.ts
@@ -23,13 +23,13 @@ export class PortBehaviorValidator {
     // Regex that validates a set statement.
     // Has the label type and label value that should be set as capturing groups.
     private static readonly SET_REGEX =
-        /^set +([A-Za-z][A-Za-z0-9_]*)\.([A-Za-z][A-Za-z0-9_]*) *= *(?: +|!|TRUE|FALSE|\|\||&&|\(|\)|[A-Za-z][A-Za-z0-9_;]*(?:\.[A-Za-z][A-Za-z0-9_;]*){2})+$/;
+        /^set +([A-Za-z][A-Za-z0-9_]*)\.([A-Za-z][A-Za-z0-9_]*) *= *(?: +|!|TRUE|FALSE|\|\||&&|\(|\)|[A-Za-z][A-Za-z0-9_\|]*(?:\.[A-Za-z][A-Za-z0-9_\|]*){2})+$/;
     // Regex that is used to extract all inputs, their label types and label values from a set statement.
     // Each input is a match with the input name, label type and label value as capturing groups.
     private static readonly SET_REGEX_EXPRESSION_INPUTS =
-        /([A-Za-z][A-Za-z0-9_;]*)\.([A-Za-z][A-Za-z0-9_;]*)\.([A-Za-z][A-Za-z0-9_;]*)/g;
+        /([A-Za-z][A-Za-z0-9_\|]*)\.([A-Za-z][A-Za-z0-9_\|]*)\.([A-Za-z][A-Za-z0-9_\|]*)/g;
     // Regex matching alphanumeric characters.
-    public static readonly REGEX_ALPHANUMERIC = /[A-Za-z0-9_]+/;
+    public static readonly REGEX_ALPHANUMERIC = /[A-Za-z0-9_\|]+/;
 
     constructor(@inject(LabelTypeRegistry) @optional() private readonly labelTypeRegistry?: LabelTypeRegistry) {}
 

--- a/src/features/dfdElements/outputPortBehaviorValidation.ts
+++ b/src/features/dfdElements/outputPortBehaviorValidation.ts
@@ -23,7 +23,7 @@ export class PortBehaviorValidator {
     // Regex that validates assignments
     // Matches "Assignment({input_Pins};TERM_REGEX;{out_Label})"
     private static readonly ASSIGNMENT_REGEX =
-        /^Assignment\(\{(([A-Za-z0-9_][A-Za-z0-9_\|]+(,\s*[A-Za-z0-9_\|]+)*)?)\};(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z0-9_]*\.[A-Za-z0-9_]*))+;\{(((([A-Za-z0-9_]*)\.[A-Za-z0-9_]*)+(,\s*([A-Za-z0-9_]*\.[A-Za-z0-9_]*))*)?)\}\)+$/;
+        /^Assignment\(\{(([A-Za-z0-9_][A-Za-z0-9_\|]+(,\s*[A-Za-z0-9_\|]+)*)?)\};(\s*|!|TRUE|FALSE|\|\||&&|\(|\)|([A-Za-z0-9_]*\.[A-Za-z0-9_]*))+;\{(((([A-Za-z0-9_]+)\.[A-Za-z0-9_]+)+(,\s*([A-Za-z0-9_]+\.[A-Za-z0-9_]+))*)?)\}\)+$/;
 
     // Regex that validates forwarding
     // Matches "Forwarding({input_pins})"

--- a/src/features/dfdElements/outputPortBehaviorValidation.ts
+++ b/src/features/dfdElements/outputPortBehaviorValidation.ts
@@ -341,6 +341,7 @@ export class PortBehaviorValidator {
             }
 
             if (typeValuePair.indexOf(".") !== -1) {
+                if (typeValuePair.split(".")[1] === null || typeValuePair.split(".")[1] === "") continue;
                 const inputLabelValue = typeValuePair.split(".")[1].trim();
 
                 const inputLabelTypeObject = this.labelTypeRegistry

--- a/src/features/dfdElements/outputPortBehaviorValidation.ts
+++ b/src/features/dfdElements/outputPortBehaviorValidation.ts
@@ -23,11 +23,11 @@ export class PortBehaviorValidator {
     // Regex that validates a set statement.
     // Has the label type and label value that should be set as capturing groups.
     private static readonly SET_REGEX =
-        /^set +([A-Za-z][A-Za-z0-9_]*)\.([A-Za-z][A-Za-z0-9_]*) *= *(?: +|!|TRUE|FALSE|\|\||&&|\(|\)|[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*){2})+$/;
+        /^set +([A-Za-z][A-Za-z0-9_]*)\.([A-Za-z][A-Za-z0-9_]*) *= *(?: +|!|TRUE|FALSE|\|\||&&|\(|\)|[A-Za-z][A-Za-z0-9_;]*(?:\.[A-Za-z][A-Za-z0-9_;]*){2})+$/;
     // Regex that is used to extract all inputs, their label types and label values from a set statement.
     // Each input is a match with the input name, label type and label value as capturing groups.
     private static readonly SET_REGEX_EXPRESSION_INPUTS =
-        /([A-Za-z][A-Za-z0-9_]*)\.([A-Za-z][A-Za-z0-9_]*)\.([A-Za-z][A-Za-z0-9_]*)/g;
+        /([A-Za-z][A-Za-z0-9_;]*)\.([A-Za-z][A-Za-z0-9_;]*)\.([A-Za-z][A-Za-z0-9_;]*)/g;
     // Regex matching alphanumeric characters.
     public static readonly REGEX_ALPHANUMERIC = /[A-Za-z0-9_]+/;
 

--- a/src/features/dfdElements/outputPortEditUi.ts
+++ b/src/features/dfdElements/outputPortEditUi.ts
@@ -193,7 +193,10 @@ class MonacoEditorDfdBehaviorCompletionProvider implements monaco.languages.Comp
         if (
             model.getValueInRange(
                 new monaco.Range(position.lineNumber, position.column - 1, position.lineNumber, position.column),
-            ) === "{"
+            ) === "{" &&
+            model.getValueInRange(
+                new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column + 1),
+            ) !== "}"
         ) {
             return {
                 suggestions: [curlyBracketCompletion],
@@ -228,19 +231,24 @@ class MonacoEditorDfdBehaviorCompletionProvider implements monaco.languages.Comp
 
         // Check if we're inside the input list (i.e., inside first curly braces `{}`)
         const openBraceIndex = line.indexOf("{");
-        const firstSemicolonIndex = line.indexOf(";");
+        const closingBraceIndex = line.indexOf("}");
 
+        console.log("Moin" + column);
+        console.log("Moin" + openBraceIndex);
+        console.log("Moin" + closingBraceIndex);
+        console.log("Moin" + (openBraceIndex !== -1 && (closingBraceIndex === -1 || column <= closingBraceIndex)));
         // If the first semicolon hasn't been typed yet, assume we're inside the input list
-        if (openBraceIndex !== -1 && (firstSemicolonIndex === -1 || column < firstSemicolonIndex)) {
+        if (openBraceIndex !== -1 && (closingBraceIndex === -1 || column <= closingBraceIndex + 1)) {
             // Inside `{List of available inputs}` section
             return this.getInputCompletions(model, position, availableInputs);
         }
 
         // If the second semicolon hasn't been typed yet, assume we're typing in the term section or outPorts list
+        const firstSemicolonIndex = line.indexOf(";");
         const secondSemicolonIndex = line.indexOf(";", firstSemicolonIndex + 1);
         const secondOpenBraceIndex = line.indexOf("{", openBraceIndex + 1);
 
-        if (secondSemicolonIndex !== -1 && column > secondSemicolonIndex) {
+        if (secondSemicolonIndex !== -1 && column > secondSemicolonIndex + 1) {
             // If the second semicolon hasn't been typed but we're inside the second curly brace, assume it's outPorts
             if (secondOpenBraceIndex !== -1 && column > secondOpenBraceIndex) {
                 // We're inside the `{List of outPorts}` section

--- a/src/features/dfdElements/outputPortEditUi.ts
+++ b/src/features/dfdElements/outputPortEditUi.ts
@@ -224,7 +224,6 @@ class MonacoEditorDfdBehaviorCompletionProvider implements monaco.languages.Comp
         availableInputs: string[],
     ): monaco.languages.CompletionItem[] {
         const line = model.getLineContent(position.lineNumber);
-        const currentWord = model.getWordUntilPosition(position);
         const column = position.column;
 
         // Check if we're inside the input list (i.e., inside first curly braces `{}`)
@@ -282,7 +281,6 @@ class MonacoEditorDfdBehaviorCompletionProvider implements monaco.languages.Comp
         availableInputs: string[],
     ): monaco.languages.CompletionItem[] {
         const line = model.getLineContent(position.lineNumber);
-        const currentWord = model.getWordUntilPosition(position);
         const column = position.column;
 
         // Check if we're inside the input list (i.e., inside first curly braces `{}`)

--- a/src/features/dfdElements/outputPortEditUi.ts
+++ b/src/features/dfdElements/outputPortEditUi.ts
@@ -103,7 +103,7 @@ const dfdBehaviorLanguageMonarchDefinition: monaco.languages.IMonarchLanguage = 
         root: [
             // keywords and identifiers
             [
-                /[a-zA-Z_;$][\w$]*/,
+                /[a-zA-Z_\|$][\w$]*/,
                 {
                     cases: {
                         "@keywords": "keyword",

--- a/src/features/dfdElements/outputPortEditUi.ts
+++ b/src/features/dfdElements/outputPortEditUi.ts
@@ -82,7 +82,7 @@ export class OutputPortEditUIMouseListener extends MouseListener {
 }
 
 // More information and playground website for testing: https://microsoft.github.io/monaco-editor/monarch.html
-const statementKeywords = ["forward", "set"];
+const statementKeywords = ["Forwarding({})", "Assignment({})"];
 const constantsKeywords = ["TRUE", "FALSE"];
 const dfdBehaviorLanguageMonarchDefinition: monaco.languages.IMonarchLanguage = {
     keywords: [...statementKeywords, ...constantsKeywords],
@@ -140,7 +140,7 @@ class MonacoEditorDfdBehaviorCompletionProvider implements monaco.languages.Comp
 
     // Auto open completions after typing a dot. Useful for the set statement where
     // components are delimited by dots.
-    triggerCharacters = ["."];
+    triggerCharacters = [".", ";", "{"];
 
     provideCompletionItems(
         model: monaco.editor.ITextModel,
@@ -159,7 +159,8 @@ class MonacoEditorDfdBehaviorCompletionProvider implements monaco.languages.Comp
                 suggestions: statementKeywords.map((keyword) => ({
                     label: keyword,
                     kind: monaco.languages.CompletionItemKind.Keyword,
-                    insertText: keyword,
+                    insertText: keyword.slice(0, -2) + "$0" + keyword.slice(-2),
+                    insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet, // Treat insertText as a snippet
                     // Replace full line with new statement start keyword
                     range: new monaco.Range(
                         position.lineNumber,
@@ -180,15 +181,34 @@ class MonacoEditorDfdBehaviorCompletionProvider implements monaco.languages.Comp
 
         const availableInputs = parent.getAvailableInputs().filter((input) => input !== undefined) as string[];
 
+        const curlyBracketCompletion = {
+            label: "{",
+            kind: monaco.languages.CompletionItemKind.Snippet,
+            insertText: "$0}", // Automatically add closing curly bracket and position cursor inside
+            insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+            range: new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column),
+        };
+
+        // Add the curly bracket completion when the user types a curly bracket
+        if (
+            model.getValueInRange(
+                new monaco.Range(position.lineNumber, position.column - 1, position.lineNumber, position.column),
+            ) === "{"
+        ) {
+            return {
+                suggestions: [curlyBracketCompletion],
+            };
+        }
+
         // Suggestions per statement type
         switch (statementType?.word) {
-            case "set":
+            case "Assignment":
                 return {
-                    suggestions: this.getSetStatementCompletions(model, position, availableInputs),
+                    suggestions: this.getAssignmentCompletions(model, position, availableInputs),
                 };
-            case "forward":
+            case "Forwarding":
                 return {
-                    suggestions: this.getInputCompletions(model, position, availableInputs),
+                    suggestions: this.getForwardingCompletions(model, position, availableInputs),
                 };
         }
 
@@ -198,53 +218,112 @@ class MonacoEditorDfdBehaviorCompletionProvider implements monaco.languages.Comp
         };
     }
 
-    private getSetStatementCompletions(
+    private getAssignmentCompletions(
         model: monaco.editor.ITextModel,
         position: monaco.Position,
         availableInputs: string[],
     ): monaco.languages.CompletionItem[] {
         const line = model.getLineContent(position.lineNumber);
+        const currentWord = model.getWordUntilPosition(position);
+        const column = position.column;
 
-        // Find the start of the current expression
-        // -1 because the column is to the right of the last char => last filled column is -1
+        // Check if we're inside the input list (i.e., inside first curly braces `{}`)
+        const openBraceIndex = line.indexOf("{");
+        const firstSemicolonIndex = line.indexOf(";");
+
+        // If the first semicolon hasn't been typed yet, assume we're inside the input list
+        if (openBraceIndex !== -1 && (firstSemicolonIndex === -1 || column < firstSemicolonIndex)) {
+            // Inside `{List of available inputs}` section
+            return this.getInputCompletions(model, position, availableInputs);
+        }
+
+        // If the second semicolon hasn't been typed yet, assume we're typing in the term section or outPorts list
+        const secondSemicolonIndex = line.indexOf(";", firstSemicolonIndex + 1);
+        const secondOpenBraceIndex = line.indexOf("{", openBraceIndex + 1);
+
+        if (secondSemicolonIndex !== -1 && column > secondSemicolonIndex) {
+            // If the second semicolon hasn't been typed but we're inside the second curly brace, assume it's outPorts
+            if (secondOpenBraceIndex !== -1 && column > secondOpenBraceIndex) {
+                // We're inside the `{List of outPorts}` section
+                return this.getOutLabelCompletions(model, position);
+            } else {
+                return [
+                    {
+                        label: "{",
+                        kind: monaco.languages.CompletionItemKind.Snippet,
+                        insertText: "{$0}", // Automatically add closing curly bracket and position cursor inside
+                        insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+                        range: new monaco.Range(
+                            position.lineNumber,
+                            position.column,
+                            position.lineNumber,
+                            position.column,
+                        ),
+                    },
+                ];
+            }
+        }
+
+        if (line.charAt(column - 2) === ".") {
+            // If the last character is a ".", return only getOutLabelCompletions
+            return this.getOutLabelCompletions(model, position);
+        }
+
+        const constantsCompletions = this.getConstantsCompletions(model, position);
+        const outLabelCompletions = this.getOutLabelCompletions(model, position);
+
+        // Return combined completions
+        return [...constantsCompletions, ...outLabelCompletions];
+    }
+
+    private getForwardingCompletions(
+        model: monaco.editor.ITextModel,
+        position: monaco.Position,
+        availableInputs: string[],
+    ): monaco.languages.CompletionItem[] {
+        const line = model.getLineContent(position.lineNumber);
+        const currentWord = model.getWordUntilPosition(position);
+        const column = position.column;
+
+        // Check if we're inside the input list (i.e., inside first curly braces `{}`)
+        const openBraceIndex = line.indexOf("{");
+
+        // If the first semicolon hasn't been typed yet, assume we're inside the input list
+        if (openBraceIndex !== -1 && column > openBraceIndex) {
+            // Inside `{List of available inputs}` section
+            return this.getInputCompletions(model, position, availableInputs);
+        } else {
+            return [];
+        }
+    }
+
+    private getOutLabelCompletions(
+        model: monaco.editor.ITextModel,
+        position: monaco.Position,
+    ): monaco.languages.CompletionItem[] {
+        const line = model.getLineContent(position.lineNumber);
+
+        // Find the start of the current expression (Type or value)
         let currentExpressionStart = position.column - 1;
         while (currentExpressionStart > 0) {
-            const currentChar = line[currentExpressionStart - 1]; // column is 1-based but array is 0-based => -1
-
-            if (currentChar !== "." && !currentChar.match(PortBehaviorValidator.REGEX_ALPHANUMERIC)) {
+            const currentChar = line[currentExpressionStart - 1]; // column is 1-based, array is 0-based
+            if (currentChar !== "." && !currentChar.match(/[A-Za-z0-9_]/)) {
                 break;
             }
-
             currentExpressionStart--;
         }
 
-        const currentExpression = line.substring(currentExpressionStart - 1, position.column);
+        const currentExpression = line.substring(currentExpressionStart, position.column);
         const expressionParts = currentExpression.split(".");
-        // Check whether the position is the assignment target (aka the left side of the "=" or missing equals)
-        const equalsIdx = line.indexOf("=");
-        const isTargetLabel = equalsIdx == -1 || equalsIdx > currentExpressionStart;
 
-        if (isTargetLabel) {
-            // Left hand side: labelType.labelValue (is for the target node, so we don't need to specify)
-            if (expressionParts.length === 1) {
+        switch (expressionParts.length) {
+            case 1:
+                // If there's only one part, we're completing the `Type`
                 return this.getLabelTypeCompletions(model, position);
-            } else {
-                return this.getLabelValueCompletions(model, position, expressionParts[0]);
-            }
-        } else {
-            // Right hand side: input.labelType.labelValue or constant
-            switch (expressionParts.length) {
-                case 1:
-                    return [
-                        ...this.getInputCompletions(model, position, availableInputs),
-                        ...this.getConstantsCompletions(model, position),
-                    ];
-                case 2:
-                    return this.getLabelTypeCompletions(model, position);
-                case 3:
-                    const labelTypeName = expressionParts[1];
-                    return this.getLabelValueCompletions(model, position, labelTypeName);
-            }
+            case 2:
+                // If there's already a dot, we complete the `value` for the specific `Type`
+                const labelTypeName = expressionParts[0];
+                return this.getLabelValueCompletions(model, position, labelTypeName);
         }
 
         return [];

--- a/src/features/dfdElements/outputPortEditUi.ts
+++ b/src/features/dfdElements/outputPortEditUi.ts
@@ -103,7 +103,7 @@ const dfdBehaviorLanguageMonarchDefinition: monaco.languages.IMonarchLanguage = 
         root: [
             // keywords and identifiers
             [
-                /[a-zA-Z_$][\w$]*/,
+                /[a-zA-Z_;$][\w$]*/,
                 {
                     cases: {
                         "@keywords": "keyword",

--- a/src/features/dfdElements/outputPortEditUi.ts
+++ b/src/features/dfdElements/outputPortEditUi.ts
@@ -233,10 +233,6 @@ class MonacoEditorDfdBehaviorCompletionProvider implements monaco.languages.Comp
         const openBraceIndex = line.indexOf("{");
         const closingBraceIndex = line.indexOf("}");
 
-        console.log("Moin" + column);
-        console.log("Moin" + openBraceIndex);
-        console.log("Moin" + closingBraceIndex);
-        console.log("Moin" + (openBraceIndex !== -1 && (closingBraceIndex === -1 || column <= closingBraceIndex)));
         // If the first semicolon hasn't been typed yet, assume we're inside the input list
         if (openBraceIndex !== -1 && (closingBraceIndex === -1 || column <= closingBraceIndex + 1)) {
             // Inside `{List of available inputs}` section

--- a/src/features/dfdElements/ports.tsx
+++ b/src/features/dfdElements/ports.tsx
@@ -54,7 +54,7 @@ export class DfdInputPortImpl extends SPortImpl {
         if (edgeNames.length === 0) {
             return undefined;
         } else {
-            return edgeNames.sort().join("_");
+            return edgeNames.sort().join(";");
         }
     }
 

--- a/src/features/dfdElements/ports.tsx
+++ b/src/features/dfdElements/ports.tsx
@@ -54,7 +54,7 @@ export class DfdInputPortImpl extends SPortImpl {
         if (edgeNames.length === 0) {
             return undefined;
         } else {
-            return edgeNames.sort().join(";");
+            return edgeNames.sort().join("|");
         }
     }
 

--- a/src/features/serialize/defaultDiagram.json
+++ b/src/features/serialize/defaultDiagram.json
@@ -1,10 +1,16 @@
 {
     "model": {
-        "scroll": {
+        "canvasBounds": {
             "x": 0,
-            "y": 0
+            "y": 0,
+            "width": 1278,
+            "height": 1324
         },
-        "zoom": 3.854984894259819,
+        "scroll": {
+            "x": 181.68489464915504,
+            "y": -12.838536201820945
+        },
+        "zoom": 6.057478948161569,
         "position": {
             "x": 0,
             "y": 0
@@ -13,6 +19,7 @@
             "width": -1,
             "height": -1
         },
+        "features": {},
         "type": "graph",
         "id": "root",
         "children": [
@@ -39,25 +46,6 @@
                 "ports": [
                     {
                         "position": {
-                            "x": 31,
-                            "y": 38.5
-                        },
-                        "size": {
-                            "width": -1,
-                            "height": -1
-                        },
-                        "strokeWidth": 0,
-                        "selected": false,
-                        "hoverFeedback": false,
-                        "opacity": 1,
-                        "behavior": "set Sensitivity.Personal = TRUE",
-                        "features": {},
-                        "id": "4wbyft",
-                        "type": "port:dfd-output",
-                        "children": []
-                    },
-                    {
-                        "position": {
                             "x": 58.5,
                             "y": 7
                         },
@@ -76,6 +64,25 @@
                     },
                     {
                         "position": {
+                            "x": 31,
+                            "y": 38.5
+                        },
+                        "size": {
+                            "width": -1,
+                            "height": -1
+                        },
+                        "strokeWidth": 0,
+                        "selected": false,
+                        "hoverFeedback": false,
+                        "opacity": 1,
+                        "behavior": "Assignment({};TRUE;{Sensitivity.Personal})",
+                        "features": {},
+                        "id": "4wbyft",
+                        "type": "port:dfd-output",
+                        "children": []
+                    },
+                    {
+                        "position": {
                             "x": 58.5,
                             "y": 25.5
                         },
@@ -87,7 +94,7 @@
                         "selected": false,
                         "hoverFeedback": false,
                         "opacity": 1,
-                        "behavior": "set Sensitivity.Public = TRUE",
+                        "behavior": "Assignment({};TRUE;{Sensitivity.Public})",
                         "features": {},
                         "id": "wksxi8",
                         "type": "port:dfd-output",
@@ -97,70 +104,6 @@
                 "features": {},
                 "id": "7oii5l",
                 "type": "node:input-output",
-                "children": []
-            },
-            {
-                "position": {
-                    "x": 422.5,
-                    "y": 59
-                },
-                "size": {
-                    "width": -1,
-                    "height": -1
-                },
-                "strokeWidth": 0,
-                "selected": false,
-                "hoverFeedback": false,
-                "opacity": 1,
-                "text": "Database",
-                "labels": [
-                    {
-                        "labelTypeId": "gvia09",
-                        "labelTypeValueId": "5hnugm"
-                    }
-                ],
-                "ports": [
-                    {
-                        "position": {
-                            "x": -3.5,
-                            "y": 5
-                        },
-                        "size": {
-                            "width": -1,
-                            "height": -1
-                        },
-                        "strokeWidth": 0,
-                        "selected": false,
-                        "hoverFeedback": false,
-                        "opacity": 1,
-                        "behavior": "set Sensitivity.Public = TRUE",
-                        "features": {},
-                        "id": "1j7bn5",
-                        "type": "port:dfd-output",
-                        "children": []
-                    },
-                    {
-                        "position": {
-                            "x": -3.5,
-                            "y": 28
-                        },
-                        "size": {
-                            "width": -1,
-                            "height": -1
-                        },
-                        "strokeWidth": 0,
-                        "selected": true,
-                        "hoverFeedback": true,
-                        "opacity": 1,
-                        "features": {},
-                        "id": "scljwi",
-                        "type": "port:dfd-input",
-                        "children": []
-                    }
-                ],
-                "features": {},
-                "id": "8j2r1g",
-                "type": "node:storage",
                 "children": []
             },
             {
@@ -181,25 +124,6 @@
                 "ports": [
                     {
                         "position": {
-                            "x": 58.5,
-                            "y": 13
-                        },
-                        "size": {
-                            "width": -1,
-                            "height": -1
-                        },
-                        "strokeWidth": 0,
-                        "selected": false,
-                        "hoverFeedback": false,
-                        "opacity": 1,
-                        "behavior": "forward request",
-                        "features": {},
-                        "id": "bsqjm",
-                        "type": "port:dfd-output",
-                        "children": []
-                    },
-                    {
-                        "position": {
                             "x": -3.5,
                             "y": 13
                         },
@@ -214,6 +138,25 @@
                         "features": {},
                         "id": "ti4ri7",
                         "type": "port:dfd-input",
+                        "children": []
+                    },
+                    {
+                        "position": {
+                            "x": 58.5,
+                            "y": 13
+                        },
+                        "size": {
+                            "width": -1,
+                            "height": -1
+                        },
+                        "strokeWidth": 0,
+                        "selected": false,
+                        "hoverFeedback": false,
+                        "opacity": 1,
+                        "behavior": "Forwarding({request})",
+                        "features": {},
+                        "id": "bsqjm",
+                        "type": "port:dfd-output",
                         "children": []
                     }
                 ],
@@ -266,10 +209,10 @@
                             "height": -1
                         },
                         "strokeWidth": 0,
-                        "selected": false,
+                        "selected": true,
                         "hoverFeedback": false,
                         "opacity": 1,
-                        "behavior": "forward items",
+                        "behavior": "Forwarding({items})",
                         "features": {},
                         "id": "y1p7qq",
                         "type": "port:dfd-output",
@@ -279,32 +222,6 @@
                 "features": {},
                 "id": "4myuyr",
                 "type": "node:function",
-                "children": []
-            },
-            {
-                "routingPoints": [],
-                "selected": false,
-                "hoverFeedback": false,
-                "opacity": 1,
-                "features": {},
-                "id": "n81f3b",
-                "type": "edge:arrow",
-                "sourceId": "1j7bn5",
-                "targetId": "0hfzu",
-                "text": "items",
-                "children": []
-            },
-            {
-                "routingPoints": [],
-                "selected": false,
-                "hoverFeedback": false,
-                "opacity": 1,
-                "features": {},
-                "id": "hi397b",
-                "type": "edge:arrow",
-                "sourceId": "y1p7qq",
-                "targetId": "nhcrad",
-                "text": "items",
                 "children": []
             },
             {
@@ -325,25 +242,6 @@
                 "ports": [
                     {
                         "position": {
-                            "x": 29,
-                            "y": -3.5
-                        },
-                        "size": {
-                            "width": -1,
-                            "height": -1
-                        },
-                        "strokeWidth": 0,
-                        "selected": false,
-                        "hoverFeedback": false,
-                        "opacity": 1,
-                        "behavior": "forward data\nset Encryption.Encrypted = TRUE",
-                        "features": {},
-                        "id": "3wntc",
-                        "type": "port:dfd-output",
-                        "children": []
-                    },
-                    {
-                        "position": {
                             "x": -3.5,
                             "y": 15.5
                         },
@@ -358,6 +256,25 @@
                         "features": {},
                         "id": "kqjy4g",
                         "type": "port:dfd-input",
+                        "children": []
+                    },
+                    {
+                        "position": {
+                            "x": 29,
+                            "y": -3.5
+                        },
+                        "size": {
+                            "width": -1,
+                            "height": -1
+                        },
+                        "strokeWidth": 0,
+                        "selected": false,
+                        "hoverFeedback": false,
+                        "opacity": 1,
+                        "behavior": "Forwarding({data})\nAssignment({};TRUE;{Encryption.Encrypted})",
+                        "features": {},
+                        "id": "3wntc",
+                        "type": "port:dfd-output",
                         "children": []
                     }
                 ],
@@ -413,7 +330,7 @@
                         "selected": false,
                         "hoverFeedback": false,
                         "opacity": 1,
-                        "behavior": "forward data",
+                        "behavior": "Forwarding({data})",
                         "features": {},
                         "id": "vnkg73",
                         "type": "port:dfd-output",
@@ -423,19 +340,6 @@
                 "features": {},
                 "id": "z9v1jp",
                 "type": "node:function",
-                "children": []
-            },
-            {
-                "routingPoints": [],
-                "selected": false,
-                "hoverFeedback": false,
-                "opacity": 1,
-                "features": {},
-                "id": "vq8g3l",
-                "type": "edge:arrow",
-                "sourceId": "4wbyft",
-                "targetId": "2331e8",
-                "text": "data",
                 "children": []
             },
             {
@@ -485,7 +389,7 @@
                         "selected": false,
                         "hoverFeedback": false,
                         "opacity": 1,
-                        "behavior": "forward data",
+                        "behavior": "Forwarding({data})",
                         "features": {},
                         "id": "eedb56",
                         "type": "port:dfd-output",
@@ -495,6 +399,83 @@
                 "features": {},
                 "id": "js61f",
                 "type": "node:function",
+                "children": []
+            },
+            {
+                "position": {
+                    "x": 422.5,
+                    "y": 59
+                },
+                "size": {
+                    "width": -1,
+                    "height": -1
+                },
+                "strokeWidth": 0,
+                "selected": false,
+                "hoverFeedback": false,
+                "opacity": 1,
+                "text": "Database",
+                "labels": [
+                    {
+                        "labelTypeId": "gvia09",
+                        "labelTypeValueId": "5hnugm"
+                    }
+                ],
+                "ports": [
+                    {
+                        "position": {
+                            "x": -3.5,
+                            "y": 23
+                        },
+                        "size": {
+                            "width": -1,
+                            "height": -1
+                        },
+                        "strokeWidth": 0,
+                        "selected": false,
+                        "hoverFeedback": false,
+                        "opacity": 1,
+                        "features": {},
+                        "id": "scljwi",
+                        "type": "port:dfd-input",
+                        "children": []
+                    },
+                    {
+                        "position": {
+                            "x": -3.5,
+                            "y": 0.5
+                        },
+                        "size": {
+                            "width": -1,
+                            "height": -1
+                        },
+                        "strokeWidth": 0,
+                        "selected": false,
+                        "hoverFeedback": false,
+                        "opacity": 1,
+                        "behavior": "Assignment({};TRUE;{Sensitivity.Public})",
+                        "features": {},
+                        "id": "1j7bn5",
+                        "type": "port:dfd-output",
+                        "children": []
+                    }
+                ],
+                "features": {},
+                "id": "8j2r1g",
+                "type": "node:storage",
+                "children": []
+            },
+            {
+                "routingPoints": [],
+                "selected": false,
+                "hoverFeedback": false,
+                "opacity": 1,
+                "features": {},
+                "id": "vq8g3l",
+                "type": "edge:arrow",
+                "sourceId": "4wbyft",
+                "targetId": "2331e8",
+                "text": "data",
                 "children": []
             },
             {
@@ -529,20 +510,6 @@
                 "hoverFeedback": false,
                 "opacity": 1,
                 "features": {},
-                "id": "uflsc",
-                "type": "edge:arrow",
-                "sourceId": "wksxi8",
-                "targetId": "ti4ri7",
-                "text": "request",
-                "routerKind": "polyline",
-                "children": []
-            },
-            {
-                "routingPoints": [],
-                "selected": false,
-                "hoverFeedback": false,
-                "opacity": 1,
-                "features": {},
                 "id": "ojjvtp",
                 "type": "edge:arrow",
                 "sourceId": "3wntc",
@@ -561,6 +528,46 @@
                 "sourceId": "bsqjm",
                 "targetId": "scljwi",
                 "text": "request",
+                "children": []
+            },
+            {
+                "routingPoints": [],
+                "selected": false,
+                "hoverFeedback": false,
+                "opacity": 1,
+                "features": {},
+                "id": "uflsc",
+                "type": "edge:arrow",
+                "sourceId": "wksxi8",
+                "targetId": "ti4ri7",
+                "text": "request",
+                "routerKind": "polyline",
+                "children": []
+            },
+            {
+                "routingPoints": [],
+                "selected": false,
+                "hoverFeedback": false,
+                "opacity": 1,
+                "features": {},
+                "id": "n81f3b",
+                "type": "edge:arrow",
+                "sourceId": "1j7bn5",
+                "targetId": "0hfzu",
+                "text": "items",
+                "children": []
+            },
+            {
+                "routingPoints": [],
+                "selected": false,
+                "hoverFeedback": false,
+                "opacity": 1,
+                "features": {},
+                "id": "hi397b",
+                "type": "edge:arrow",
+                "sourceId": "y1p7qq",
+                "targetId": "nhcrad",
+                "text": "items",
                 "children": []
             }
         ]


### PR DESCRIPTION
Instead of using the WebEditor specific behavior definition, assignments are now defined like they are in the [DFD-MetaModel](https://github.com/DataFlowAnalysis/DFD-Metamodel).

Former set-Actions now work like this:
Assignment({input_Pins};Term;{out_Label}) e.g. Assignment({data, request};Sensitivity.Personal || TRUE;{Sensitivity.Public})

forwarding now like this:
Forwarding({input_pins})
 e.g. Forwading({data|request, encrypt}) [with data|request being the pin where both data and request arrive]

Auto-Completion and validation have been adjusted