### PR TITLE
Fix issues with annotation tooltip

### DIFF
--- a/src/features/dfdElements/nodeAnnotationUi.ts
+++ b/src/features/dfdElements/nodeAnnotationUi.ts
@@ -171,8 +171,8 @@ export class DfdNodeAnnotationUI extends AbstractUIExtension {
 
         // Set tooltip size and scroll to prevent them from growing out of the screen
         containerElement.style.overflowY = "auto";
-        this.annotationParagraph.style.textWrap = "wrap";
-        this.annotationParagraph.style.overflowWrap = "anywhere";
+        this.annotationParagraph.style.whiteSpace = "normal";
+        this.annotationParagraph.style.wordBreak = "break-word";
         const screenWidth = window.innerWidth;
         const screenHeight = window.innerHeight;
         containerElement.style.maxWidth = `${Math.max(screenWidth - annotationPosition.x - 50, 100)}px`;

--- a/src/features/dfdElements/nodeAnnotationUi.ts
+++ b/src/features/dfdElements/nodeAnnotationUi.ts
@@ -162,8 +162,21 @@ export class DfdNodeAnnotationUI extends AbstractUIExtension {
         // because the cursor is going a bit over the model and then the popup would re-show
         // with the new position after the timeout.
         const mousePosition = this.mouseListener.getMousePosition();
-        containerElement.style.left = `${mousePosition.x - 2}px`;
-        containerElement.style.top = `${mousePosition.y - 2}px`;
+        const annotationPosition = {
+            x: mousePosition.x - 2,
+            y: mousePosition.y - 2,
+        };
+        containerElement.style.left = `${annotationPosition.x}px`;
+        containerElement.style.top = `${annotationPosition.y}px`;
+
+        // Set tooltip size and scroll to prevent them from growing out of the screen
+        containerElement.style.overflowY = "auto";
+        this.annotationParagraph.style.textWrap = "wrap";
+        this.annotationParagraph.style.overflowWrap = "anywhere";
+        const screenWidth = window.innerWidth;
+        const screenHeight = window.innerHeight;
+        containerElement.style.maxWidth = `${Math.max(screenWidth - annotationPosition.x - 50, 100)}px`;
+        containerElement.style.maxHeight = `${Math.max(screenHeight - annotationPosition.y - 50, 50)}px`;
 
         // Set content
         if (!node.annotation) {

--- a/src/features/dfdElements/nodeAnnotationUi.ts
+++ b/src/features/dfdElements/nodeAnnotationUi.ts
@@ -172,7 +172,7 @@ export class DfdNodeAnnotationUI extends AbstractUIExtension {
         }
 
         const { message, icon } = node.annotation;
-        this.annotationParagraph.innerText = message;
+        this.annotationParagraph.innerHTML = message;
 
         if (icon) {
             const iconI = document.createElement("i");


### PR DESCRIPTION
This PR fixes two issue with the annotation tooltip:

The tooltip can now display html code and not just plain text.

The tooltip can no longer grow outside of the screen.
For this it calculates the tooltips distance to the edge of the screen and sets its maximum size accordingly.
Text gets broken up at the spaces or other seperator symbols if possible, otherwise an inword break could be inserted.
If the broken up text is too long to be fully displayed, since the tooltip would grow out of the bottom of the page, a scrollbar will be displayed.

![grafik](https://github.com/user-attachments/assets/eb25b27b-c9d8-45a9-8fa4-3680c6a902a7)
