### PR TITLE
Flip accordion arrow on help ui

### DIFF
--- a/src/common/commonStyling.css
+++ b/src/common/commonStyling.css
@@ -70,6 +70,14 @@ kbd {
        the text would be selected otherwise due to a double click. */
     -webkit-user-select: none;
     user-select: none;
+
+    /* Default orientation of the arrow: pointing down */
+    --arrow-scale: 1;
+}
+
+.accordion-button.flip-arrow {
+    /* Default orientation of the arrow: pointing up */
+    --arrow-scale: -1;
 }
 
 .accordion-button::after {
@@ -88,10 +96,10 @@ kbd {
 
     vertical-align: text-top;
     transition: transform 500ms ease;
-    transform: scaleY(1);
+    transform: scaleY(var(--arrow-scale));
 }
 
 .accordion-state:checked ~ label .accordion-button::after {
     /* flip arrow in y direction */
-    transform: scaleY(-1);
+    transform: scaleY(calc(var(--arrow-scale) * -1));
 }

--- a/src/common/helpUi.ts
+++ b/src/common/helpUi.ts
@@ -20,7 +20,7 @@ export class HelpUI extends AbstractUIExtension {
         containerElement.innerHTML = `
             <input type="checkbox" id="accordion-state-help" class="accordion-state" hidden>
             <label id="help-ui-accordion-label" for="accordion-state-help">
-                <div class="accordion-button">
+                <div class="accordion-button flip-arrow">
                     Keyboard Shortcuts | Help
                 </div>
             </label>


### PR DESCRIPTION
Previously on the help ui pointed downwards when it was closed and up when it was open. Now the arrow is flipped to align with its semantic meaning.

Old:
![grafik](https://github.com/user-attachments/assets/bc09e197-3cb0-48f6-9d02-97a6ef13da2a)

New:
![grafik](https://github.com/user-attachments/assets/0aeac510-0d6c-4e9b-8dd3-148fdbf0191c)
