### PR TITLE
remove features if present in model

### DIFF
--- a/src/features/serialize/load.ts
+++ b/src/features/serialize/load.ts
@@ -251,6 +251,14 @@ export class LoadDiagramCommand extends Command {
      * @param modelSchema The model schema to preprocess
      */
     public static preprocessModelSchema(modelSchema: SModelRoot): void {
+        // These properties are all not included in the root typing and if present are not loaded and handled correctly. So they are removed.
+        if ("features" in modelSchema) {
+            delete modelSchema["features"];
+        }
+        if ("canvasBounds" in modelSchema) {
+            delete modelSchema["canvasBounds"];
+        }
+
         if (modelSchema.children) {
             modelSchema.children.forEach((child: SModelElement) => this.preprocessModelSchema(child));
         }


### PR DESCRIPTION
If the features are present on a model after loading, they do not have an underlying implementation. This leads to errors when trying to display the diagram.
Previously this was solved by this
https://github.com/DataFlowAnalysis/WebEditor/blob/6b84cc2a5f401c44b343aebff753c72b32e312c6/src/features/serialize/load.ts#L253-L256

#98 falsely removed these lines.

They are now added again in an easier to read method and longer explanation