### PR TITLE
Bump monaco-editor to newest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "husky": "^9.1.7",
                 "inversify": "^6.2.2",
                 "lint-staged": "^15.5.1",
-                "monaco-editor": "^0.45.0",
+                "monaco-editor": "^0.52.2",
                 "prettier": "^3.5.3",
                 "reflect-metadata": "^0.2.2",
                 "sprotty": "^1.4.0",
@@ -2479,10 +2479,11 @@
             }
         },
         "node_modules/monaco-editor": {
-            "version": "0.45.0",
-            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.45.0.tgz",
-            "integrity": "sha512-mjv1G1ZzfEE3k9HZN0dQ2olMdwIfaeAAjFiwNprLfYNRSz7ctv9XuCT7gPtBGrMUeV1/iZzYKj17Khu1hxoHOA==",
-            "dev": true
+            "version": "0.52.2",
+            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+            "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -4936,9 +4937,9 @@
             }
         },
         "monaco-editor": {
-            "version": "0.45.0",
-            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.45.0.tgz",
-            "integrity": "sha512-mjv1G1ZzfEE3k9HZN0dQ2olMdwIfaeAAjFiwNprLfYNRSz7ctv9XuCT7gPtBGrMUeV1/iZzYKj17Khu1hxoHOA==",
+            "version": "0.52.2",
+            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+            "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
             "dev": true
         },
         "ms": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "husky": "^9.1.7",
         "inversify": "^6.2.2",
         "lint-staged": "^15.5.1",
-        "monaco-editor": "^0.45.0",
+        "monaco-editor": "^0.52.2",
         "prettier": "^3.5.3",
         "reflect-metadata": "^0.2.2",
         "sprotty": "^1.4.0",

--- a/src/features/constraintMenu/ConstraintMenu.ts
+++ b/src/features/constraintMenu/ConstraintMenu.ts
@@ -6,7 +6,7 @@ import { Constraint, ConstraintRegistry } from "./constraintRegistry";
 
 // Enable hover feature that is used to show validation errors.
 // Inline completions are enabled to allow autocompletion of keywords and inputs/label types/label values.
-import "monaco-editor/esm/vs/editor/contrib/hover/browser/hover";
+import "monaco-editor/esm/vs/editor/contrib/hover/browser/hoverContribution";
 import "monaco-editor/esm/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.js";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import {

--- a/src/features/dfdElements/outputPortEditUi.ts
+++ b/src/features/dfdElements/outputPortEditUi.ts
@@ -28,7 +28,7 @@ import { DFDBehaviorRefactorer } from "./behaviorRefactorer";
 
 // Enable hover feature that is used to show validation errors.
 // Inline completions are enabled to allow autocompletion of keywords and inputs/label types/label values.
-import "monaco-editor/esm/vs/editor/contrib/hover/browser/hover";
+import "monaco-editor/esm/vs/editor/contrib/hover/browser/hoverContribution";
 import "monaco-editor/esm/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution.js";
 
 import "./outputPortEditUi.css";


### PR DESCRIPTION
Bumps monaco to the newest version

They restructured the js files for the hover of markers between v0.48.0 and v0.49.0. This PR adapts them