### PR TITLE
Fix Auto Resizing of nodes

### DIFF
--- a/src/features/dfdElements/nodes.tsx
+++ b/src/features/dfdElements/nodes.tsx
@@ -90,12 +90,12 @@ export abstract class DfdNodeImpl extends DynamicChildrenNode implements WithEdi
             return this.minimumWidth + DfdNodeImpl.WIDTH_PADDING;
         }
         const textWidth = calculateTextSize(this.text).width;
-        const editableLableWidth = this.editableLabel ? calculateTextSize(this.editableLabel.text).width : 0;
+        const editableLabelWidth = this.editableLabel ? calculateTextSize(this.editableLabel.text).width : 0;
         const labelWidths = this.labels.map(
             (labelAssignment) => DfdNodeLabelRenderer.computeLabelContent(labelAssignment)[1],
         );
 
-        const neededWidth = Math.max(...labelWidths, textWidth, editableLableWidth, DfdNodeImpl.DEFAULT_WIDTH);
+        const neededWidth = Math.max(...labelWidths, textWidth, editableLabelWidth, DfdNodeImpl.DEFAULT_WIDTH);
         return neededWidth + DfdNodeImpl.WIDTH_PADDING;
     }
 


### PR DESCRIPTION
The size of the node was not taken into account when calculating the width of dfd nodes.

Fixes https://github.com/DataFlowAnalysis/DataFlowAnalysis/issues/271