### PR TITLE
Fix loading indicator staying when canceling load

### DIFF
--- a/src/features/serialize/load.ts
+++ b/src/features/serialize/load.ts
@@ -148,6 +148,7 @@ export class LoadDiagramCommand extends Command {
             const file = await this.getModelFile();
             if (!file) {
                 // No file was selected, skip
+                this.loadingIndicator?.hideIndicator();
                 return context.root;
             }
 


### PR DESCRIPTION
When canceling the file chooser from the json load, the web editor would not remove the loading indicator

fixes https://github.com/DataFlowAnalysis/DataFlowAnalysis/issues/280