### PR TITLE
Add cookie prefix

### DIFF
--- a/src/features/settingsMenu/SettingsManager.ts
+++ b/src/features/settingsMenu/SettingsManager.ts
@@ -11,7 +11,7 @@ export class SettingsManager {
     private _hideEdgeLabelsCheckbox?: HTMLInputElement;
     private _simplifyNodeNames = false;
     private _simplifyNodeNamesCheckbox?: HTMLInputElement;
-    private static readonly layoutMethodLocalStorageKey = "settings";
+    private static readonly layoutMethodLocalStorageKey = "dfdwebeditor:settings";
 
     constructor(@inject(TYPES.IActionDispatcher) protected readonly dispatcher: ActionDispatcher) {
         this.layoutMethod = (localStorage.getItem(SettingsManager.layoutMethodLocalStorageKey) ??

--- a/src/features/settingsMenu/themeManager.ts
+++ b/src/features/settingsMenu/themeManager.ts
@@ -20,7 +20,7 @@ export class ThemeManager {
     private static SYSTEM_DEFAULT =
         window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? Theme.DARK : Theme.LIGHT;
     private themeSelect?: HTMLSelectElement;
-    private static readonly localStorageKey = "theme";
+    private static readonly localStorageKey = "dfdwebeditor:theme";
 
     constructor(
         @multiInject(SWITCHABLE) protected switchables: Switchable[],


### PR DESCRIPTION
Adds a prefix to the cookie to clearly match it to this app.

This is usefull, because with multiple local vite applications using cookies a differing syntax between them can lead to errors