### PR TITLE
Fix ports snapping to ports

### DIFF
--- a/src/features/dfdElements/portSnapper.ts
+++ b/src/features/dfdElements/portSnapper.ts
@@ -51,7 +51,7 @@ export class PortAwareSnapper implements ISnapper {
     private snapPort(position: Point, element: SPortImpl): Point {
         const parentElement = element.parent;
 
-        if (!(parentElement instanceof SNodeImpl)) {
+        if (parentElement instanceof SPortImpl) {
             // Parent is not a node, so we cannot snap the port to the node edges
             return position;
         }

--- a/src/features/dfdElements/portSnapper.ts
+++ b/src/features/dfdElements/portSnapper.ts
@@ -51,6 +51,11 @@ export class PortAwareSnapper implements ISnapper {
     private snapPort(position: Point, element: SPortImpl): Point {
         const parentElement = element.parent;
 
+        if (!(parentElement instanceof SNodeImpl)) {
+            // Parent is not a node, so we cannot snap the port to the node edges
+            return position;
+        }
+
         if (!isBoundsAware(parentElement)) {
             // Cannot get the parent size, just return the original position and don't snap
             return position;


### PR DESCRIPTION
Fixes https://github.com/DataFlowAnalysis/DataFlowAnalysis/issues/312

Previously, ports could snap to any diagram elements including other ports. This could lead to crashes